### PR TITLE
Add support for AGP 8.x 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace "com.bdk.bdk_flutter"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-    namespace "com.bdk.bdk_flutter"
+    namespace "io.bdk.f.bdk_flutter"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.bdk.f.bdk_flutter"></manifest>
+<manifest></manifest>


### PR DESCRIPTION
Resolves #142  added support for AGP 8.x by adding namespace to build.gradle and removing namespace from AndroidManifest