### PR TITLE
0.31.2 policy patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Updated `flutter_rust_bridge` to `2.0.0`.
 - `PartiallySignedTransaction`, `ScriptBuf` & `Transaction`.
 #### Changed
 - `partiallySignedTransaction.serialize()` serialize the data as raw binary.
+#### Fixed
+- Thread `frb_workerpool` panicked on Sql database access.
 
 ## [0.31.2-dev.2]
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 Updated `flutter_rust_bridge` to `2.0.0`.
 #### APIs added
 - Exposed `createTestnet` & `createMutinynet` to `Blockchain`.
+- Exposed  `policies` in `Wallet`.
+- Exposed `policyPath` in `TxBuilder`.
+- Exposed `id`, `requiresPath`, `item`, `satisfaction`, `contribution` in `Policy` class.
 - Overrode `toString()` for `Address`, `DerivationPath`, `Descriptor`, `DescriptorPublicKey` , `DescriptorSecretKey`, `Mnemonic`,
-- `PartiallySignedTransaction`, `ScriptBuf` & `Transaction`. 
+- `PartiallySignedTransaction`, `ScriptBuf` & `Transaction`.
 #### Changed
 - `partiallySignedTransaction.serialize()` serialize the data as raw binary.
-#### Fixed
-- Thread `frb_workerpool` panicked on Sql database access.
-
 
 ## [0.31.2-dev.2]
 #### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,6 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
     namespace "io.bdk.f.bdk_flutter"
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.bdk.f.bdk_flutter"></manifest>
+<manifest></manifest>

--- a/example/integration_test /full_cycle_test.dart
+++ b/example/integration_test /full_cycle_test.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:bdk_flutter/bdk_flutter.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  group('Descriptor & Wallet', () {
+    setUp(() async {});
+    testWidgets('generating psbt using a muti-sig wallet', (_) async {
+      final externalDescriptor = await Descriptor.create(
+          descriptor:
+              "wsh(thresh(2,pk(tpubD6NzVbkrYhZ4XJBfEJ6gt9DiVdfWJijsQTCE3jtXByW3Tk6AVGQ3vL1NNxg3SjB7QkJAuutACCQjrXD8zdZSM1ZmBENszCqy49ECEHmD6rf/0/*),sj:and_v(v:pk(tpubD6NzVbkrYhZ4YfAr3jCBRk4SpqB9L1Hh442y83njwfMaker7EqZd7fHMqyTWrfRYJ1e5t2ue6BYjW5i5yQnmwqbzY1a3kfqNxog1AFcD1aE/0/*),n:older(6)),snj:and_v(v:pk(tprv8ZgxMBicQKsPeitVUz3s6cfyCECovNP7t82FaKPa4UKqV1kssWcXgLkMDjzDbgG9GWoza4pL7z727QitfzkiwX99E1Has3T3a1MKHvYWmQZ/0/*),after(630000))))",
+          network: Network.signet);
+      final internalDescriptor = await Descriptor.create(
+          descriptor:
+              "wsh(thresh(2,pk(tpubD6NzVbkrYhZ4XJBfEJ6gt9DiVdfWJijsQTCE3jtXByW3Tk6AVGQ3vL1NNxg3SjB7QkJAuutACCQjrXD8zdZSM1ZmBENszCqy49ECEHmD6rf/1/*),sj:and_v(v:pk(tpubD6NzVbkrYhZ4YfAr3jCBRk4SpqB9L1Hh442y83njwfMaker7EqZd7fHMqyTWrfRYJ1e5t2ue6BYjW5i5yQnmwqbzY1a3kfqNxog1AFcD1aE/1/*),n:older(6)),snj:and_v(v:pk(tprv8ZgxMBicQKsPeitVUz3s6cfyCECovNP7t82FaKPa4UKqV1kssWcXgLkMDjzDbgG9GWoza4pL7z727QitfzkiwX99E1Has3T3a1MKHvYWmQZ/1/*),after(630000))))",
+          network: Network.signet);
+
+      final wallet = await Wallet.create(
+          descriptor: externalDescriptor,
+          changeDescriptor: internalDescriptor,
+          network: Network.signet,
+          databaseConfig: const DatabaseConfig.memory());
+      final blockchain = await Blockchain.createMutinynet();
+      wallet.sync(blockchain: blockchain);
+      debugPrint("Wallet balance: ${wallet.getBalance().total}");
+      final toAddress = wallet
+          .getAddress(addressIndex: const AddressIndex.increase())
+          .address;
+      debugPrint("Wallet address: ${toAddress.toString()}");
+      final externalWalletPolicy = wallet.policies(KeychainKind.externalChain);
+      final ineternalWalletPolicy = wallet.policies(KeychainKind.internalChain);
+      if (externalWalletPolicy != null && ineternalWalletPolicy != null) {
+        // Construct external and internal policy paths
+        final extPath = {
+          ineternalWalletPolicy.id(): Uint32List.fromList([0, 1])
+        };
+        debugPrint("External Policy path: $extPath\n");
+
+        final intPath = {
+          ineternalWalletPolicy.id(): Uint32List.fromList([0, 1])
+        };
+        debugPrint("Internal Policy Path: $intPath\n");
+
+        // Build the transaction
+        final txBuilder = TxBuilder()
+            .addRecipient(
+              toAddress.scriptPubkey(),
+              BigInt.from(1000),
+            )
+            .doNotSpendChange()
+            .policyPath(KeychainKind.internalChain, intPath)
+            .policyPath(KeychainKind.externalChain, extPath);
+
+        final (psbt, _) = await txBuilder.finish(wallet);
+        debugPrint("Transaction serialized: ${psbt.toString()}\n");
+      }
+    });
+  });
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -181,6 +181,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -210,6 +215,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -218,6 +228,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   json_annotation:
     dependency: transitive
     description:
@@ -314,6 +329,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   pub_semver:
     dependency: transitive
     description:
@@ -375,6 +406,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -439,6 +478,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   yaml:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,7 +32,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
+  integration_test:
+    sdk: flutter
+  flutter_driver:
+    sdk: flutter 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -139,6 +139,10 @@ typedef struct wire_cst_bdk_script_buf {
   struct wire_cst_list_prim_u_8_strict *bytes;
 } wire_cst_bdk_script_buf;
 
+typedef struct wire_cst_bdk_policy {
+  uintptr_t ptr;
+} wire_cst_bdk_policy;
+
 typedef struct wire_cst_LockTime_Blocks {
   uint32_t field0;
 } wire_cst_LockTime_Blocks;
@@ -297,6 +301,21 @@ typedef struct wire_cst_rbf_value {
   union RbfValueKind kind;
 } wire_cst_rbf_value;
 
+typedef struct wire_cst_list_prim_usize_strict {
+  uintptr_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_usize_strict;
+
+typedef struct wire_cst_record_string_list_prim_usize_strict {
+  struct wire_cst_list_prim_u_8_strict *field0;
+  struct wire_cst_list_prim_usize_strict *field1;
+} wire_cst_record_string_list_prim_usize_strict;
+
+typedef struct wire_cst_list_record_string_list_prim_usize_strict {
+  struct wire_cst_record_string_list_prim_usize_strict *ptr;
+  int32_t len;
+} wire_cst_list_record_string_list_prim_usize_strict;
+
 typedef struct wire_cst_AddressError_Base58 {
   struct wire_cst_list_prim_u_8_strict *field0;
 } wire_cst_AddressError_Base58;
@@ -357,6 +376,11 @@ typedef struct wire_cst_block_time {
   uint32_t height;
   uint64_t timestamp;
 } wire_cst_block_time;
+
+typedef struct wire_cst_condition {
+  uint32_t *csv;
+  struct wire_cst_lock_time *timelock;
+} wire_cst_condition;
 
 typedef struct wire_cst_ConsensusError_Io {
   struct wire_cst_list_prim_u_8_strict *field0;
@@ -469,10 +493,78 @@ typedef struct wire_cst_hex_error {
   union HexErrorKind kind;
 } wire_cst_hex_error;
 
+typedef struct wire_cst_PkOrF_Pubkey {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_Pubkey;
+
+typedef struct wire_cst_PkOrF_XOnlyPubkey {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_XOnlyPubkey;
+
+typedef struct wire_cst_PkOrF_Fingerprint {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_Fingerprint;
+
+typedef union PkOrFKind {
+  struct wire_cst_PkOrF_Pubkey Pubkey;
+  struct wire_cst_PkOrF_XOnlyPubkey XOnlyPubkey;
+  struct wire_cst_PkOrF_Fingerprint Fingerprint;
+} PkOrFKind;
+
+typedef struct wire_cst_pk_or_f {
+  int32_t tag;
+  union PkOrFKind kind;
+} wire_cst_pk_or_f;
+
+typedef struct wire_cst_list_bdk_policy {
+  struct wire_cst_bdk_policy *ptr;
+  int32_t len;
+} wire_cst_list_bdk_policy;
+
+typedef struct wire_cst_list_condition {
+  struct wire_cst_condition *ptr;
+  int32_t len;
+} wire_cst_list_condition;
+
 typedef struct wire_cst_list_local_utxo {
   struct wire_cst_local_utxo *ptr;
   int32_t len;
 } wire_cst_list_local_utxo;
+
+typedef struct wire_cst_list_pk_or_f {
+  struct wire_cst_pk_or_f *ptr;
+  int32_t len;
+} wire_cst_list_pk_or_f;
+
+typedef struct wire_cst_list_prim_u_32_strict {
+  uint32_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_u_32_strict;
+
+typedef struct wire_cst_list_prim_u_64_strict {
+  uint64_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_u_64_strict;
+
+typedef struct wire_cst_record_list_prim_u_32_strict_list_condition {
+  struct wire_cst_list_prim_u_32_strict *field0;
+  struct wire_cst_list_condition *field1;
+} wire_cst_record_list_prim_u_32_strict_list_condition;
+
+typedef struct wire_cst_list_record_list_prim_u_32_strict_list_condition {
+  struct wire_cst_record_list_prim_u_32_strict_list_condition *ptr;
+  int32_t len;
+} wire_cst_list_record_list_prim_u_32_strict_list_condition;
+
+typedef struct wire_cst_record_u_32_list_condition {
+  uint32_t field0;
+  struct wire_cst_list_condition *field1;
+} wire_cst_record_u_32_list_condition;
+
+typedef struct wire_cst_list_record_u_32_list_condition {
+  struct wire_cst_record_u_32_list_condition *ptr;
+  int32_t len;
+} wire_cst_list_record_u_32_list_condition;
 
 typedef struct wire_cst_transaction_details {
   struct wire_cst_bdk_transaction *transaction;
@@ -722,6 +814,102 @@ typedef struct wire_cst_record_bdk_psbt_transaction_details {
   struct wire_cst_transaction_details field1;
 } wire_cst_record_bdk_psbt_transaction_details;
 
+typedef struct wire_cst_Satisfaction_Partial {
+  uint64_t n;
+  uint64_t m;
+  struct wire_cst_list_prim_u_64_strict *items;
+  bool *sorted;
+  struct wire_cst_list_record_u_32_list_condition *conditions;
+} wire_cst_Satisfaction_Partial;
+
+typedef struct wire_cst_Satisfaction_PartialComplete {
+  uint64_t n;
+  uint64_t m;
+  struct wire_cst_list_prim_u_64_strict *items;
+  bool *sorted;
+  struct wire_cst_list_record_list_prim_u_32_strict_list_condition *conditions;
+} wire_cst_Satisfaction_PartialComplete;
+
+typedef struct wire_cst_Satisfaction_Complete {
+  struct wire_cst_condition *condition;
+} wire_cst_Satisfaction_Complete;
+
+typedef struct wire_cst_Satisfaction_None {
+  struct wire_cst_list_prim_u_8_strict *msg;
+} wire_cst_Satisfaction_None;
+
+typedef union SatisfactionKind {
+  struct wire_cst_Satisfaction_Partial Partial;
+  struct wire_cst_Satisfaction_PartialComplete PartialComplete;
+  struct wire_cst_Satisfaction_Complete Complete;
+  struct wire_cst_Satisfaction_None None;
+} SatisfactionKind;
+
+typedef struct wire_cst_satisfaction {
+  int32_t tag;
+  union SatisfactionKind kind;
+} wire_cst_satisfaction;
+
+typedef struct wire_cst_SatisfiableItem_EcdsaSignature {
+  struct wire_cst_pk_or_f *key;
+} wire_cst_SatisfiableItem_EcdsaSignature;
+
+typedef struct wire_cst_SatisfiableItem_SchnorrSignature {
+  struct wire_cst_pk_or_f *key;
+} wire_cst_SatisfiableItem_SchnorrSignature;
+
+typedef struct wire_cst_SatisfiableItem_Sha256Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Sha256Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Hash256Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Hash256Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Ripemd160Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Ripemd160Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Hash160Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Hash160Preimage;
+
+typedef struct wire_cst_SatisfiableItem_AbsoluteTimelock {
+  struct wire_cst_lock_time *value;
+} wire_cst_SatisfiableItem_AbsoluteTimelock;
+
+typedef struct wire_cst_SatisfiableItem_RelativeTimelock {
+  uint32_t value;
+} wire_cst_SatisfiableItem_RelativeTimelock;
+
+typedef struct wire_cst_SatisfiableItem_Multisig {
+  struct wire_cst_list_pk_or_f *keys;
+  uint64_t threshold;
+} wire_cst_SatisfiableItem_Multisig;
+
+typedef struct wire_cst_SatisfiableItem_Thresh {
+  struct wire_cst_list_bdk_policy *items;
+  uint64_t threshold;
+} wire_cst_SatisfiableItem_Thresh;
+
+typedef union SatisfiableItemKind {
+  struct wire_cst_SatisfiableItem_EcdsaSignature EcdsaSignature;
+  struct wire_cst_SatisfiableItem_SchnorrSignature SchnorrSignature;
+  struct wire_cst_SatisfiableItem_Sha256Preimage Sha256Preimage;
+  struct wire_cst_SatisfiableItem_Hash256Preimage Hash256Preimage;
+  struct wire_cst_SatisfiableItem_Ripemd160Preimage Ripemd160Preimage;
+  struct wire_cst_SatisfiableItem_Hash160Preimage Hash160Preimage;
+  struct wire_cst_SatisfiableItem_AbsoluteTimelock AbsoluteTimelock;
+  struct wire_cst_SatisfiableItem_RelativeTimelock RelativeTimelock;
+  struct wire_cst_SatisfiableItem_Multisig Multisig;
+  struct wire_cst_SatisfiableItem_Thresh Thresh;
+} SatisfiableItemKind;
+
+typedef struct wire_cst_satisfiable_item {
+  int32_t tag;
+  union SatisfiableItemKind kind;
+} wire_cst_satisfiable_item;
+
 void frbgen_bdk_flutter_wire__crate__api__blockchain__bdk_blockchain_broadcast(int64_t port_,
                                                                                struct wire_cst_bdk_blockchain *that,
                                                                                struct wire_cst_bdk_transaction *transaction);
@@ -886,6 +1074,18 @@ WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_address_scr
 
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_address_to_qr_uri(struct wire_cst_bdk_address *that);
 
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction(struct wire_cst_bdk_policy *that);
+
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_as_string(struct wire_cst_bdk_script_buf *that);
 
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_empty(void);
@@ -974,6 +1174,9 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_new(int64_t port_,
                                                                  int32_t network,
                                                                  struct wire_cst_database_config *database_config);
 
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies(struct wire_cst_bdk_wallet *ptr,
+                                                                                      int32_t keychain);
+
 void frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sign(int64_t port_,
                                                                   struct wire_cst_bdk_wallet *ptr,
                                                                   struct wire_cst_bdk_psbt *psbt,
@@ -1004,6 +1207,8 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish(int64_t port
                                                                     bool drain_wallet,
                                                                     struct wire_cst_bdk_script_buf *drain_to,
                                                                     struct wire_cst_rbf_value *rbf,
+                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *internal_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *external_policy_path,
                                                                     struct wire_cst_list_prim_u_8_loose *data);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(const void *ptr);
@@ -1021,6 +1226,10 @@ void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkblockchain
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor(const void *ptr);
 
 void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor(const void *ptr);
+
+void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy(const void *ptr);
+
+void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy(const void *ptr);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorPublicKey(const void *ptr);
 
@@ -1064,6 +1273,8 @@ struct wire_cst_bdk_descriptor_secret_key *frbgen_bdk_flutter_cst_new_box_autoad
 
 struct wire_cst_bdk_mnemonic *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_mnemonic(void);
 
+struct wire_cst_bdk_policy *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy(void);
+
 struct wire_cst_bdk_psbt *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_psbt(void);
 
 struct wire_cst_bdk_script_buf *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_script_buf(void);
@@ -1075,6 +1286,10 @@ struct wire_cst_bdk_wallet *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_wallet(vo
 struct wire_cst_block_time *frbgen_bdk_flutter_cst_new_box_autoadd_block_time(void);
 
 struct wire_cst_blockchain_config *frbgen_bdk_flutter_cst_new_box_autoadd_blockchain_config(void);
+
+bool *frbgen_bdk_flutter_cst_new_box_autoadd_bool(bool value);
+
+struct wire_cst_condition *frbgen_bdk_flutter_cst_new_box_autoadd_condition(void);
 
 struct wire_cst_consensus_error *frbgen_bdk_flutter_cst_new_box_autoadd_consensus_error(void);
 
@@ -1098,6 +1313,8 @@ struct wire_cst_lock_time *frbgen_bdk_flutter_cst_new_box_autoadd_lock_time(void
 
 struct wire_cst_out_point *frbgen_bdk_flutter_cst_new_box_autoadd_out_point(void);
 
+struct wire_cst_pk_or_f *frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f(void);
+
 struct wire_cst_psbt_sig_hash_type *frbgen_bdk_flutter_cst_new_box_autoadd_psbt_sig_hash_type(void);
 
 struct wire_cst_rbf_value *frbgen_bdk_flutter_cst_new_box_autoadd_rbf_value(void);
@@ -1120,15 +1337,33 @@ uint64_t *frbgen_bdk_flutter_cst_new_box_autoadd_u_64(uint64_t value);
 
 uint8_t *frbgen_bdk_flutter_cst_new_box_autoadd_u_8(uint8_t value);
 
+struct wire_cst_list_bdk_policy *frbgen_bdk_flutter_cst_new_list_bdk_policy(int32_t len);
+
+struct wire_cst_list_condition *frbgen_bdk_flutter_cst_new_list_condition(int32_t len);
+
 struct wire_cst_list_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_list_prim_u_8_strict(int32_t len);
 
 struct wire_cst_list_local_utxo *frbgen_bdk_flutter_cst_new_list_local_utxo(int32_t len);
 
 struct wire_cst_list_out_point *frbgen_bdk_flutter_cst_new_list_out_point(int32_t len);
 
+struct wire_cst_list_pk_or_f *frbgen_bdk_flutter_cst_new_list_pk_or_f(int32_t len);
+
+struct wire_cst_list_prim_u_32_strict *frbgen_bdk_flutter_cst_new_list_prim_u_32_strict(int32_t len);
+
+struct wire_cst_list_prim_u_64_strict *frbgen_bdk_flutter_cst_new_list_prim_u_64_strict(int32_t len);
+
 struct wire_cst_list_prim_u_8_loose *frbgen_bdk_flutter_cst_new_list_prim_u_8_loose(int32_t len);
 
 struct wire_cst_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(int32_t len);
+
+struct wire_cst_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_prim_usize_strict(int32_t len);
+
+struct wire_cst_list_record_list_prim_u_32_strict_list_condition *frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(int32_t len);
+
+struct wire_cst_list_record_string_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(int32_t len);
+
+struct wire_cst_list_record_u_32_list_condition *frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition(int32_t len);
 
 struct wire_cst_list_script_amount *frbgen_bdk_flutter_cst_new_list_script_amount(int32_t len);
 
@@ -1148,12 +1383,15 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_descriptor_public_key);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_descriptor_secret_key);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_mnemonic);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_psbt);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_script_buf);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_transaction);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_wallet);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_block_time);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_blockchain_config);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bool);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_consensus_error);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_database_config);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_descriptor_error);
@@ -1165,6 +1403,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_local_utxo);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_lock_time);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_out_point);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_psbt_sig_hash_type);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_rbf_value);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_record_out_point_input_usize);
@@ -1176,11 +1415,20 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_32);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_64);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_8);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_bdk_policy);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_list_prim_u_8_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_local_utxo);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_out_point);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_pk_or_f);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_32_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_64_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_loose);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_script_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_transaction_details);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_tx_in);
@@ -1189,6 +1437,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkbitcoinbip32DerivationPath);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkblockchainAnyBlockchain);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysDescriptorPublicKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysDescriptorSecretKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysKeyMap);
@@ -1199,6 +1448,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinbip32DerivationPath);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkblockchainAnyBlockchain);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorPublicKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorSecretKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysKeyMap);
@@ -1256,6 +1506,12 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_payload);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_script);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_to_qr_uri);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_as_string);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_empty);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_from_hex);
@@ -1284,6 +1540,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_list_unspent);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_network);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_new);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sign);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__finish_bump_fee_tx_builder);

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -301,20 +301,20 @@ typedef struct wire_cst_rbf_value {
   union RbfValueKind kind;
 } wire_cst_rbf_value;
 
-typedef struct wire_cst_list_prim_usize_strict {
-  uintptr_t *ptr;
+typedef struct wire_cst_list_prim_u_32_strict {
+  uint32_t *ptr;
   int32_t len;
-} wire_cst_list_prim_usize_strict;
+} wire_cst_list_prim_u_32_strict;
 
-typedef struct wire_cst_record_string_list_prim_usize_strict {
+typedef struct wire_cst_record_string_list_prim_u_32_strict {
   struct wire_cst_list_prim_u_8_strict *field0;
-  struct wire_cst_list_prim_usize_strict *field1;
-} wire_cst_record_string_list_prim_usize_strict;
+  struct wire_cst_list_prim_u_32_strict *field1;
+} wire_cst_record_string_list_prim_u_32_strict;
 
-typedef struct wire_cst_list_record_string_list_prim_usize_strict {
-  struct wire_cst_record_string_list_prim_usize_strict *ptr;
+typedef struct wire_cst_list_record_string_list_prim_u_32_strict {
+  struct wire_cst_record_string_list_prim_u_32_strict *ptr;
   int32_t len;
-} wire_cst_list_record_string_list_prim_usize_strict;
+} wire_cst_list_record_string_list_prim_u_32_strict;
 
 typedef struct wire_cst_AddressError_Base58 {
   struct wire_cst_list_prim_u_8_strict *field0;
@@ -535,11 +535,6 @@ typedef struct wire_cst_list_pk_or_f {
   struct wire_cst_pk_or_f *ptr;
   int32_t len;
 } wire_cst_list_pk_or_f;
-
-typedef struct wire_cst_list_prim_u_32_strict {
-  uint32_t *ptr;
-  int32_t len;
-} wire_cst_list_prim_u_32_strict;
 
 typedef struct wire_cst_list_prim_u_64_strict {
   uint64_t *ptr;
@@ -1207,8 +1202,8 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish(int64_t port
                                                                     bool drain_wallet,
                                                                     struct wire_cst_bdk_script_buf *drain_to,
                                                                     struct wire_cst_rbf_value *rbf,
-                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *internal_policy_path,
-                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *external_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_u_32_strict *internal_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_u_32_strict *external_policy_path,
                                                                     struct wire_cst_list_prim_u_8_loose *data);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(const void *ptr);
@@ -1357,11 +1352,9 @@ struct wire_cst_list_prim_u_8_loose *frbgen_bdk_flutter_cst_new_list_prim_u_8_lo
 
 struct wire_cst_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(int32_t len);
 
-struct wire_cst_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_prim_usize_strict(int32_t len);
-
 struct wire_cst_list_record_list_prim_u_32_strict_list_condition *frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(int32_t len);
 
-struct wire_cst_list_record_string_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(int32_t len);
+struct wire_cst_list_record_string_list_prim_u_32_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict(int32_t len);
 
 struct wire_cst_list_record_u_32_list_condition *frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition(int32_t len);
 
@@ -1425,9 +1418,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_64_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_loose);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_strict);
-    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_usize_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition);
-    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_script_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_transaction_details);

--- a/lib/bdk_flutter.dart
+++ b/lib/bdk_flutter.dart
@@ -40,11 +40,4 @@ export './src/generated/api/types.dart'
 export './src/generated/api/wallet.dart'
     hide BdkWallet, finishBumpFeeTxBuilder, txBuilderFinish;
 export './src/root.dart';
-export 'src/utils/exceptions.dart'
-    hide
-        mapBdkError,
-        mapAddressError,
-        mapConsensusError,
-        mapDescriptorError,
-        mapHexError,
-        BdkFfiException;
+export 'src/utils/exceptions.dart' hide mapBdkError, BdkFfiException;

--- a/lib/src/generated/api/types.dart
+++ b/lib/src/generated/api/types.dart
@@ -10,7 +10,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'types.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `default`, `default`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `hash`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `default`, `default`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `hash`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`, `try_from`
 
 @freezed
 sealed class AddressIndex with _$AddressIndex {
@@ -139,6 +139,50 @@ class BdkAddress {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is BdkAddress &&
+          runtimeType == other.runtimeType &&
+          ptr == other.ptr;
+}
+
+class BdkPolicy {
+  final Policy ptr;
+
+  const BdkPolicy({
+    required this.ptr,
+  });
+
+  String asString() => core.instance.api.crateApiTypesBdkPolicyAsString(
+        that: this,
+      );
+
+  Satisfaction contribution() =>
+      core.instance.api.crateApiTypesBdkPolicyContribution(
+        that: this,
+      );
+
+  String id() => core.instance.api.crateApiTypesBdkPolicyId(
+        that: this,
+      );
+
+  SatisfiableItem item() => core.instance.api.crateApiTypesBdkPolicyItem(
+        that: this,
+      );
+
+  bool requiresPath() => core.instance.api.crateApiTypesBdkPolicyRequiresPath(
+        that: this,
+      );
+
+  Satisfaction satisfaction() =>
+      core.instance.api.crateApiTypesBdkPolicySatisfaction(
+        that: this,
+      );
+
+  @override
+  int get hashCode => ptr.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BdkPolicy &&
           runtimeType == other.runtimeType &&
           ptr == other.ptr;
 }
@@ -312,6 +356,27 @@ enum ChangeSpendPolicy {
   ;
 }
 
+class Condition {
+  final int? csv;
+  final LockTime? timelock;
+
+  const Condition({
+    this.csv,
+    this.timelock,
+  });
+
+  @override
+  int get hashCode => csv.hashCode ^ timelock.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Condition &&
+          runtimeType == other.runtimeType &&
+          csv == other.csv &&
+          timelock == other.timelock;
+}
+
 @freezed
 sealed class DatabaseConfig with _$DatabaseConfig {
   const DatabaseConfig._();
@@ -479,6 +544,21 @@ sealed class Payload with _$Payload {
   }) = Payload_WitnessProgram;
 }
 
+@freezed
+sealed class PkOrF with _$PkOrF {
+  const PkOrF._();
+
+  const factory PkOrF.pubkey({
+    required String value,
+  }) = PkOrF_Pubkey;
+  const factory PkOrF.xOnlyPubkey({
+    required String value,
+  }) = PkOrF_XOnlyPubkey;
+  const factory PkOrF.fingerprint({
+    required String value,
+  }) = PkOrF_Fingerprint;
+}
+
 class PsbtSigHashType {
   final int inner;
 
@@ -505,6 +585,70 @@ sealed class RbfValue with _$RbfValue {
   const factory RbfValue.value(
     int field0,
   ) = RbfValue_Value;
+}
+
+@freezed
+sealed class Satisfaction with _$Satisfaction {
+  const Satisfaction._();
+
+  const factory Satisfaction.partial({
+    required BigInt n,
+    required BigInt m,
+    required Uint64List items,
+    bool? sorted,
+    required Map<int, List<Condition>> conditions,
+  }) = Satisfaction_Partial;
+  const factory Satisfaction.partialComplete({
+    required BigInt n,
+    required BigInt m,
+    required Uint64List items,
+    bool? sorted,
+    required Map<Uint32List, List<Condition>> conditions,
+  }) = Satisfaction_PartialComplete;
+  const factory Satisfaction.complete({
+    required Condition condition,
+  }) = Satisfaction_Complete;
+  const factory Satisfaction.none({
+    required String msg,
+  }) = Satisfaction_None;
+}
+
+@freezed
+sealed class SatisfiableItem with _$SatisfiableItem {
+  const SatisfiableItem._();
+
+  const factory SatisfiableItem.ecdsaSignature({
+    required PkOrF key,
+  }) = SatisfiableItem_EcdsaSignature;
+  const factory SatisfiableItem.schnorrSignature({
+    required PkOrF key,
+  }) = SatisfiableItem_SchnorrSignature;
+  const factory SatisfiableItem.sha256Preimage({
+    required String hash,
+  }) = SatisfiableItem_Sha256Preimage;
+  const factory SatisfiableItem.hash256Preimage({
+    required String hash,
+  }) = SatisfiableItem_Hash256Preimage;
+  const factory SatisfiableItem.ripemd160Preimage({
+    required String hash,
+  }) = SatisfiableItem_Ripemd160Preimage;
+  const factory SatisfiableItem.hash160Preimage({
+    required String hash,
+  }) = SatisfiableItem_Hash160Preimage;
+  const factory SatisfiableItem.absoluteTimelock({
+    required LockTime value,
+  }) = SatisfiableItem_AbsoluteTimelock;
+  const factory SatisfiableItem.relativeTimelock({
+    required int value,
+  }) = SatisfiableItem_RelativeTimelock;
+  const factory SatisfiableItem.multisig({
+    required List<PkOrF> keys,
+    required BigInt threshold,
+  }) = SatisfiableItem_Multisig;
+  const factory SatisfiableItem.thresh({
+    required List<BdkPolicy> items,
+    required BigInt threshold,
+  }) = SatisfiableItem_Thresh;
 }
 
 /// A output script and an amount of satoshis.

--- a/lib/src/generated/api/types.freezed.dart
+++ b/lib/src/generated/api/types.freezed.dart
@@ -1960,6 +1960,527 @@ abstract class Payload_WitnessProgram extends Payload {
 }
 
 /// @nodoc
+mixin _$PkOrF {
+  String get value => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String value) pubkey,
+    required TResult Function(String value) xOnlyPubkey,
+    required TResult Function(String value) fingerprint,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String value)? pubkey,
+    TResult? Function(String value)? xOnlyPubkey,
+    TResult? Function(String value)? fingerprint,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String value)? pubkey,
+    TResult Function(String value)? xOnlyPubkey,
+    TResult Function(String value)? fingerprint,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PkOrF_Pubkey value) pubkey,
+    required TResult Function(PkOrF_XOnlyPubkey value) xOnlyPubkey,
+    required TResult Function(PkOrF_Fingerprint value) fingerprint,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF_Pubkey value)? pubkey,
+    TResult? Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult? Function(PkOrF_Fingerprint value)? fingerprint,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PkOrF_Pubkey value)? pubkey,
+    TResult Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult Function(PkOrF_Fingerprint value)? fingerprint,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $PkOrFCopyWith<PkOrF> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PkOrFCopyWith<$Res> {
+  factory $PkOrFCopyWith(PkOrF value, $Res Function(PkOrF) then) =
+      _$PkOrFCopyWithImpl<$Res, PkOrF>;
+  @useResult
+  $Res call({String value});
+}
+
+/// @nodoc
+class _$PkOrFCopyWithImpl<$Res, $Val extends PkOrF>
+    implements $PkOrFCopyWith<$Res> {
+  _$PkOrFCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_value.copyWith(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PkOrF_PubkeyImplCopyWith<$Res>
+    implements $PkOrFCopyWith<$Res> {
+  factory _$$PkOrF_PubkeyImplCopyWith(
+          _$PkOrF_PubkeyImpl value, $Res Function(_$PkOrF_PubkeyImpl) then) =
+      __$$PkOrF_PubkeyImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String value});
+}
+
+/// @nodoc
+class __$$PkOrF_PubkeyImplCopyWithImpl<$Res>
+    extends _$PkOrFCopyWithImpl<$Res, _$PkOrF_PubkeyImpl>
+    implements _$$PkOrF_PubkeyImplCopyWith<$Res> {
+  __$$PkOrF_PubkeyImplCopyWithImpl(
+      _$PkOrF_PubkeyImpl _value, $Res Function(_$PkOrF_PubkeyImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$PkOrF_PubkeyImpl(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PkOrF_PubkeyImpl extends PkOrF_Pubkey {
+  const _$PkOrF_PubkeyImpl({required this.value}) : super._();
+
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'PkOrF.pubkey(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PkOrF_PubkeyImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PkOrF_PubkeyImplCopyWith<_$PkOrF_PubkeyImpl> get copyWith =>
+      __$$PkOrF_PubkeyImplCopyWithImpl<_$PkOrF_PubkeyImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String value) pubkey,
+    required TResult Function(String value) xOnlyPubkey,
+    required TResult Function(String value) fingerprint,
+  }) {
+    return pubkey(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String value)? pubkey,
+    TResult? Function(String value)? xOnlyPubkey,
+    TResult? Function(String value)? fingerprint,
+  }) {
+    return pubkey?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String value)? pubkey,
+    TResult Function(String value)? xOnlyPubkey,
+    TResult Function(String value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (pubkey != null) {
+      return pubkey(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PkOrF_Pubkey value) pubkey,
+    required TResult Function(PkOrF_XOnlyPubkey value) xOnlyPubkey,
+    required TResult Function(PkOrF_Fingerprint value) fingerprint,
+  }) {
+    return pubkey(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF_Pubkey value)? pubkey,
+    TResult? Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult? Function(PkOrF_Fingerprint value)? fingerprint,
+  }) {
+    return pubkey?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PkOrF_Pubkey value)? pubkey,
+    TResult Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult Function(PkOrF_Fingerprint value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (pubkey != null) {
+      return pubkey(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PkOrF_Pubkey extends PkOrF {
+  const factory PkOrF_Pubkey({required final String value}) =
+      _$PkOrF_PubkeyImpl;
+  const PkOrF_Pubkey._() : super._();
+
+  @override
+  String get value;
+  @override
+  @JsonKey(ignore: true)
+  _$$PkOrF_PubkeyImplCopyWith<_$PkOrF_PubkeyImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PkOrF_XOnlyPubkeyImplCopyWith<$Res>
+    implements $PkOrFCopyWith<$Res> {
+  factory _$$PkOrF_XOnlyPubkeyImplCopyWith(_$PkOrF_XOnlyPubkeyImpl value,
+          $Res Function(_$PkOrF_XOnlyPubkeyImpl) then) =
+      __$$PkOrF_XOnlyPubkeyImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String value});
+}
+
+/// @nodoc
+class __$$PkOrF_XOnlyPubkeyImplCopyWithImpl<$Res>
+    extends _$PkOrFCopyWithImpl<$Res, _$PkOrF_XOnlyPubkeyImpl>
+    implements _$$PkOrF_XOnlyPubkeyImplCopyWith<$Res> {
+  __$$PkOrF_XOnlyPubkeyImplCopyWithImpl(_$PkOrF_XOnlyPubkeyImpl _value,
+      $Res Function(_$PkOrF_XOnlyPubkeyImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$PkOrF_XOnlyPubkeyImpl(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PkOrF_XOnlyPubkeyImpl extends PkOrF_XOnlyPubkey {
+  const _$PkOrF_XOnlyPubkeyImpl({required this.value}) : super._();
+
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'PkOrF.xOnlyPubkey(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PkOrF_XOnlyPubkeyImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PkOrF_XOnlyPubkeyImplCopyWith<_$PkOrF_XOnlyPubkeyImpl> get copyWith =>
+      __$$PkOrF_XOnlyPubkeyImplCopyWithImpl<_$PkOrF_XOnlyPubkeyImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String value) pubkey,
+    required TResult Function(String value) xOnlyPubkey,
+    required TResult Function(String value) fingerprint,
+  }) {
+    return xOnlyPubkey(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String value)? pubkey,
+    TResult? Function(String value)? xOnlyPubkey,
+    TResult? Function(String value)? fingerprint,
+  }) {
+    return xOnlyPubkey?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String value)? pubkey,
+    TResult Function(String value)? xOnlyPubkey,
+    TResult Function(String value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (xOnlyPubkey != null) {
+      return xOnlyPubkey(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PkOrF_Pubkey value) pubkey,
+    required TResult Function(PkOrF_XOnlyPubkey value) xOnlyPubkey,
+    required TResult Function(PkOrF_Fingerprint value) fingerprint,
+  }) {
+    return xOnlyPubkey(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF_Pubkey value)? pubkey,
+    TResult? Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult? Function(PkOrF_Fingerprint value)? fingerprint,
+  }) {
+    return xOnlyPubkey?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PkOrF_Pubkey value)? pubkey,
+    TResult Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult Function(PkOrF_Fingerprint value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (xOnlyPubkey != null) {
+      return xOnlyPubkey(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PkOrF_XOnlyPubkey extends PkOrF {
+  const factory PkOrF_XOnlyPubkey({required final String value}) =
+      _$PkOrF_XOnlyPubkeyImpl;
+  const PkOrF_XOnlyPubkey._() : super._();
+
+  @override
+  String get value;
+  @override
+  @JsonKey(ignore: true)
+  _$$PkOrF_XOnlyPubkeyImplCopyWith<_$PkOrF_XOnlyPubkeyImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PkOrF_FingerprintImplCopyWith<$Res>
+    implements $PkOrFCopyWith<$Res> {
+  factory _$$PkOrF_FingerprintImplCopyWith(_$PkOrF_FingerprintImpl value,
+          $Res Function(_$PkOrF_FingerprintImpl) then) =
+      __$$PkOrF_FingerprintImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String value});
+}
+
+/// @nodoc
+class __$$PkOrF_FingerprintImplCopyWithImpl<$Res>
+    extends _$PkOrFCopyWithImpl<$Res, _$PkOrF_FingerprintImpl>
+    implements _$$PkOrF_FingerprintImplCopyWith<$Res> {
+  __$$PkOrF_FingerprintImplCopyWithImpl(_$PkOrF_FingerprintImpl _value,
+      $Res Function(_$PkOrF_FingerprintImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$PkOrF_FingerprintImpl(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PkOrF_FingerprintImpl extends PkOrF_Fingerprint {
+  const _$PkOrF_FingerprintImpl({required this.value}) : super._();
+
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'PkOrF.fingerprint(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PkOrF_FingerprintImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PkOrF_FingerprintImplCopyWith<_$PkOrF_FingerprintImpl> get copyWith =>
+      __$$PkOrF_FingerprintImplCopyWithImpl<_$PkOrF_FingerprintImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String value) pubkey,
+    required TResult Function(String value) xOnlyPubkey,
+    required TResult Function(String value) fingerprint,
+  }) {
+    return fingerprint(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String value)? pubkey,
+    TResult? Function(String value)? xOnlyPubkey,
+    TResult? Function(String value)? fingerprint,
+  }) {
+    return fingerprint?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String value)? pubkey,
+    TResult Function(String value)? xOnlyPubkey,
+    TResult Function(String value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (fingerprint != null) {
+      return fingerprint(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PkOrF_Pubkey value) pubkey,
+    required TResult Function(PkOrF_XOnlyPubkey value) xOnlyPubkey,
+    required TResult Function(PkOrF_Fingerprint value) fingerprint,
+  }) {
+    return fingerprint(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF_Pubkey value)? pubkey,
+    TResult? Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult? Function(PkOrF_Fingerprint value)? fingerprint,
+  }) {
+    return fingerprint?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PkOrF_Pubkey value)? pubkey,
+    TResult Function(PkOrF_XOnlyPubkey value)? xOnlyPubkey,
+    TResult Function(PkOrF_Fingerprint value)? fingerprint,
+    required TResult orElse(),
+  }) {
+    if (fingerprint != null) {
+      return fingerprint(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PkOrF_Fingerprint extends PkOrF {
+  const factory PkOrF_Fingerprint({required final String value}) =
+      _$PkOrF_FingerprintImpl;
+  const PkOrF_Fingerprint._() : super._();
+
+  @override
+  String get value;
+  @override
+  @JsonKey(ignore: true)
+  _$$PkOrF_FingerprintImplCopyWith<_$PkOrF_FingerprintImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$RbfValue {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
@@ -2255,4 +2776,3055 @@ abstract class RbfValue_Value extends RbfValue {
   @JsonKey(ignore: true)
   _$$RbfValue_ValueImplCopyWith<_$RbfValue_ValueImpl> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$Satisfaction {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<int, List<Condition>> conditions)
+        partial,
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<Uint32List, List<Condition>> conditions)
+        partialComplete,
+    required TResult Function(Condition condition) complete,
+    required TResult Function(String msg) none,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult? Function(Condition condition)? complete,
+    TResult? Function(String msg)? none,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult Function(Condition condition)? complete,
+    TResult Function(String msg)? none,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Satisfaction_Partial value) partial,
+    required TResult Function(Satisfaction_PartialComplete value)
+        partialComplete,
+    required TResult Function(Satisfaction_Complete value) complete,
+    required TResult Function(Satisfaction_None value) none,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Satisfaction_Partial value)? partial,
+    TResult? Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult? Function(Satisfaction_Complete value)? complete,
+    TResult? Function(Satisfaction_None value)? none,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Satisfaction_Partial value)? partial,
+    TResult Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult Function(Satisfaction_Complete value)? complete,
+    TResult Function(Satisfaction_None value)? none,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SatisfactionCopyWith<$Res> {
+  factory $SatisfactionCopyWith(
+          Satisfaction value, $Res Function(Satisfaction) then) =
+      _$SatisfactionCopyWithImpl<$Res, Satisfaction>;
+}
+
+/// @nodoc
+class _$SatisfactionCopyWithImpl<$Res, $Val extends Satisfaction>
+    implements $SatisfactionCopyWith<$Res> {
+  _$SatisfactionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$Satisfaction_PartialImplCopyWith<$Res> {
+  factory _$$Satisfaction_PartialImplCopyWith(_$Satisfaction_PartialImpl value,
+          $Res Function(_$Satisfaction_PartialImpl) then) =
+      __$$Satisfaction_PartialImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {BigInt n,
+      BigInt m,
+      Uint64List items,
+      bool? sorted,
+      Map<int, List<Condition>> conditions});
+}
+
+/// @nodoc
+class __$$Satisfaction_PartialImplCopyWithImpl<$Res>
+    extends _$SatisfactionCopyWithImpl<$Res, _$Satisfaction_PartialImpl>
+    implements _$$Satisfaction_PartialImplCopyWith<$Res> {
+  __$$Satisfaction_PartialImplCopyWithImpl(_$Satisfaction_PartialImpl _value,
+      $Res Function(_$Satisfaction_PartialImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? n = null,
+    Object? m = null,
+    Object? items = null,
+    Object? sorted = freezed,
+    Object? conditions = null,
+  }) {
+    return _then(_$Satisfaction_PartialImpl(
+      n: null == n
+          ? _value.n
+          : n // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+      m: null == m
+          ? _value.m
+          : m // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+      items: null == items
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as Uint64List,
+      sorted: freezed == sorted
+          ? _value.sorted
+          : sorted // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      conditions: null == conditions
+          ? _value._conditions
+          : conditions // ignore: cast_nullable_to_non_nullable
+              as Map<int, List<Condition>>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Satisfaction_PartialImpl extends Satisfaction_Partial {
+  const _$Satisfaction_PartialImpl(
+      {required this.n,
+      required this.m,
+      required this.items,
+      this.sorted,
+      required final Map<int, List<Condition>> conditions})
+      : _conditions = conditions,
+        super._();
+
+  @override
+  final BigInt n;
+  @override
+  final BigInt m;
+  @override
+  final Uint64List items;
+  @override
+  final bool? sorted;
+  final Map<int, List<Condition>> _conditions;
+  @override
+  Map<int, List<Condition>> get conditions {
+    if (_conditions is EqualUnmodifiableMapView) return _conditions;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_conditions);
+  }
+
+  @override
+  String toString() {
+    return 'Satisfaction.partial(n: $n, m: $m, items: $items, sorted: $sorted, conditions: $conditions)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Satisfaction_PartialImpl &&
+            (identical(other.n, n) || other.n == n) &&
+            (identical(other.m, m) || other.m == m) &&
+            const DeepCollectionEquality().equals(other.items, items) &&
+            (identical(other.sorted, sorted) || other.sorted == sorted) &&
+            const DeepCollectionEquality()
+                .equals(other._conditions, _conditions));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      n,
+      m,
+      const DeepCollectionEquality().hash(items),
+      sorted,
+      const DeepCollectionEquality().hash(_conditions));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Satisfaction_PartialImplCopyWith<_$Satisfaction_PartialImpl>
+      get copyWith =>
+          __$$Satisfaction_PartialImplCopyWithImpl<_$Satisfaction_PartialImpl>(
+              this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<int, List<Condition>> conditions)
+        partial,
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<Uint32List, List<Condition>> conditions)
+        partialComplete,
+    required TResult Function(Condition condition) complete,
+    required TResult Function(String msg) none,
+  }) {
+    return partial(n, m, items, sorted, conditions);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult? Function(Condition condition)? complete,
+    TResult? Function(String msg)? none,
+  }) {
+    return partial?.call(n, m, items, sorted, conditions);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult Function(Condition condition)? complete,
+    TResult Function(String msg)? none,
+    required TResult orElse(),
+  }) {
+    if (partial != null) {
+      return partial(n, m, items, sorted, conditions);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Satisfaction_Partial value) partial,
+    required TResult Function(Satisfaction_PartialComplete value)
+        partialComplete,
+    required TResult Function(Satisfaction_Complete value) complete,
+    required TResult Function(Satisfaction_None value) none,
+  }) {
+    return partial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Satisfaction_Partial value)? partial,
+    TResult? Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult? Function(Satisfaction_Complete value)? complete,
+    TResult? Function(Satisfaction_None value)? none,
+  }) {
+    return partial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Satisfaction_Partial value)? partial,
+    TResult Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult Function(Satisfaction_Complete value)? complete,
+    TResult Function(Satisfaction_None value)? none,
+    required TResult orElse(),
+  }) {
+    if (partial != null) {
+      return partial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Satisfaction_Partial extends Satisfaction {
+  const factory Satisfaction_Partial(
+          {required final BigInt n,
+          required final BigInt m,
+          required final Uint64List items,
+          final bool? sorted,
+          required final Map<int, List<Condition>> conditions}) =
+      _$Satisfaction_PartialImpl;
+  const Satisfaction_Partial._() : super._();
+
+  BigInt get n;
+  BigInt get m;
+  Uint64List get items;
+  bool? get sorted;
+  Map<int, List<Condition>> get conditions;
+  @JsonKey(ignore: true)
+  _$$Satisfaction_PartialImplCopyWith<_$Satisfaction_PartialImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$Satisfaction_PartialCompleteImplCopyWith<$Res> {
+  factory _$$Satisfaction_PartialCompleteImplCopyWith(
+          _$Satisfaction_PartialCompleteImpl value,
+          $Res Function(_$Satisfaction_PartialCompleteImpl) then) =
+      __$$Satisfaction_PartialCompleteImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {BigInt n,
+      BigInt m,
+      Uint64List items,
+      bool? sorted,
+      Map<Uint32List, List<Condition>> conditions});
+}
+
+/// @nodoc
+class __$$Satisfaction_PartialCompleteImplCopyWithImpl<$Res>
+    extends _$SatisfactionCopyWithImpl<$Res, _$Satisfaction_PartialCompleteImpl>
+    implements _$$Satisfaction_PartialCompleteImplCopyWith<$Res> {
+  __$$Satisfaction_PartialCompleteImplCopyWithImpl(
+      _$Satisfaction_PartialCompleteImpl _value,
+      $Res Function(_$Satisfaction_PartialCompleteImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? n = null,
+    Object? m = null,
+    Object? items = null,
+    Object? sorted = freezed,
+    Object? conditions = null,
+  }) {
+    return _then(_$Satisfaction_PartialCompleteImpl(
+      n: null == n
+          ? _value.n
+          : n // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+      m: null == m
+          ? _value.m
+          : m // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+      items: null == items
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as Uint64List,
+      sorted: freezed == sorted
+          ? _value.sorted
+          : sorted // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      conditions: null == conditions
+          ? _value._conditions
+          : conditions // ignore: cast_nullable_to_non_nullable
+              as Map<Uint32List, List<Condition>>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Satisfaction_PartialCompleteImpl extends Satisfaction_PartialComplete {
+  const _$Satisfaction_PartialCompleteImpl(
+      {required this.n,
+      required this.m,
+      required this.items,
+      this.sorted,
+      required final Map<Uint32List, List<Condition>> conditions})
+      : _conditions = conditions,
+        super._();
+
+  @override
+  final BigInt n;
+  @override
+  final BigInt m;
+  @override
+  final Uint64List items;
+  @override
+  final bool? sorted;
+  final Map<Uint32List, List<Condition>> _conditions;
+  @override
+  Map<Uint32List, List<Condition>> get conditions {
+    if (_conditions is EqualUnmodifiableMapView) return _conditions;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_conditions);
+  }
+
+  @override
+  String toString() {
+    return 'Satisfaction.partialComplete(n: $n, m: $m, items: $items, sorted: $sorted, conditions: $conditions)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Satisfaction_PartialCompleteImpl &&
+            (identical(other.n, n) || other.n == n) &&
+            (identical(other.m, m) || other.m == m) &&
+            const DeepCollectionEquality().equals(other.items, items) &&
+            (identical(other.sorted, sorted) || other.sorted == sorted) &&
+            const DeepCollectionEquality()
+                .equals(other._conditions, _conditions));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      n,
+      m,
+      const DeepCollectionEquality().hash(items),
+      sorted,
+      const DeepCollectionEquality().hash(_conditions));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Satisfaction_PartialCompleteImplCopyWith<
+          _$Satisfaction_PartialCompleteImpl>
+      get copyWith => __$$Satisfaction_PartialCompleteImplCopyWithImpl<
+          _$Satisfaction_PartialCompleteImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<int, List<Condition>> conditions)
+        partial,
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<Uint32List, List<Condition>> conditions)
+        partialComplete,
+    required TResult Function(Condition condition) complete,
+    required TResult Function(String msg) none,
+  }) {
+    return partialComplete(n, m, items, sorted, conditions);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult? Function(Condition condition)? complete,
+    TResult? Function(String msg)? none,
+  }) {
+    return partialComplete?.call(n, m, items, sorted, conditions);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult Function(Condition condition)? complete,
+    TResult Function(String msg)? none,
+    required TResult orElse(),
+  }) {
+    if (partialComplete != null) {
+      return partialComplete(n, m, items, sorted, conditions);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Satisfaction_Partial value) partial,
+    required TResult Function(Satisfaction_PartialComplete value)
+        partialComplete,
+    required TResult Function(Satisfaction_Complete value) complete,
+    required TResult Function(Satisfaction_None value) none,
+  }) {
+    return partialComplete(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Satisfaction_Partial value)? partial,
+    TResult? Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult? Function(Satisfaction_Complete value)? complete,
+    TResult? Function(Satisfaction_None value)? none,
+  }) {
+    return partialComplete?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Satisfaction_Partial value)? partial,
+    TResult Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult Function(Satisfaction_Complete value)? complete,
+    TResult Function(Satisfaction_None value)? none,
+    required TResult orElse(),
+  }) {
+    if (partialComplete != null) {
+      return partialComplete(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Satisfaction_PartialComplete extends Satisfaction {
+  const factory Satisfaction_PartialComplete(
+          {required final BigInt n,
+          required final BigInt m,
+          required final Uint64List items,
+          final bool? sorted,
+          required final Map<Uint32List, List<Condition>> conditions}) =
+      _$Satisfaction_PartialCompleteImpl;
+  const Satisfaction_PartialComplete._() : super._();
+
+  BigInt get n;
+  BigInt get m;
+  Uint64List get items;
+  bool? get sorted;
+  Map<Uint32List, List<Condition>> get conditions;
+  @JsonKey(ignore: true)
+  _$$Satisfaction_PartialCompleteImplCopyWith<
+          _$Satisfaction_PartialCompleteImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$Satisfaction_CompleteImplCopyWith<$Res> {
+  factory _$$Satisfaction_CompleteImplCopyWith(
+          _$Satisfaction_CompleteImpl value,
+          $Res Function(_$Satisfaction_CompleteImpl) then) =
+      __$$Satisfaction_CompleteImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Condition condition});
+}
+
+/// @nodoc
+class __$$Satisfaction_CompleteImplCopyWithImpl<$Res>
+    extends _$SatisfactionCopyWithImpl<$Res, _$Satisfaction_CompleteImpl>
+    implements _$$Satisfaction_CompleteImplCopyWith<$Res> {
+  __$$Satisfaction_CompleteImplCopyWithImpl(_$Satisfaction_CompleteImpl _value,
+      $Res Function(_$Satisfaction_CompleteImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? condition = null,
+  }) {
+    return _then(_$Satisfaction_CompleteImpl(
+      condition: null == condition
+          ? _value.condition
+          : condition // ignore: cast_nullable_to_non_nullable
+              as Condition,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Satisfaction_CompleteImpl extends Satisfaction_Complete {
+  const _$Satisfaction_CompleteImpl({required this.condition}) : super._();
+
+  @override
+  final Condition condition;
+
+  @override
+  String toString() {
+    return 'Satisfaction.complete(condition: $condition)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Satisfaction_CompleteImpl &&
+            (identical(other.condition, condition) ||
+                other.condition == condition));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, condition);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Satisfaction_CompleteImplCopyWith<_$Satisfaction_CompleteImpl>
+      get copyWith => __$$Satisfaction_CompleteImplCopyWithImpl<
+          _$Satisfaction_CompleteImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<int, List<Condition>> conditions)
+        partial,
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<Uint32List, List<Condition>> conditions)
+        partialComplete,
+    required TResult Function(Condition condition) complete,
+    required TResult Function(String msg) none,
+  }) {
+    return complete(condition);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult? Function(Condition condition)? complete,
+    TResult? Function(String msg)? none,
+  }) {
+    return complete?.call(condition);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult Function(Condition condition)? complete,
+    TResult Function(String msg)? none,
+    required TResult orElse(),
+  }) {
+    if (complete != null) {
+      return complete(condition);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Satisfaction_Partial value) partial,
+    required TResult Function(Satisfaction_PartialComplete value)
+        partialComplete,
+    required TResult Function(Satisfaction_Complete value) complete,
+    required TResult Function(Satisfaction_None value) none,
+  }) {
+    return complete(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Satisfaction_Partial value)? partial,
+    TResult? Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult? Function(Satisfaction_Complete value)? complete,
+    TResult? Function(Satisfaction_None value)? none,
+  }) {
+    return complete?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Satisfaction_Partial value)? partial,
+    TResult Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult Function(Satisfaction_Complete value)? complete,
+    TResult Function(Satisfaction_None value)? none,
+    required TResult orElse(),
+  }) {
+    if (complete != null) {
+      return complete(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Satisfaction_Complete extends Satisfaction {
+  const factory Satisfaction_Complete({required final Condition condition}) =
+      _$Satisfaction_CompleteImpl;
+  const Satisfaction_Complete._() : super._();
+
+  Condition get condition;
+  @JsonKey(ignore: true)
+  _$$Satisfaction_CompleteImplCopyWith<_$Satisfaction_CompleteImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$Satisfaction_NoneImplCopyWith<$Res> {
+  factory _$$Satisfaction_NoneImplCopyWith(_$Satisfaction_NoneImpl value,
+          $Res Function(_$Satisfaction_NoneImpl) then) =
+      __$$Satisfaction_NoneImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String msg});
+}
+
+/// @nodoc
+class __$$Satisfaction_NoneImplCopyWithImpl<$Res>
+    extends _$SatisfactionCopyWithImpl<$Res, _$Satisfaction_NoneImpl>
+    implements _$$Satisfaction_NoneImplCopyWith<$Res> {
+  __$$Satisfaction_NoneImplCopyWithImpl(_$Satisfaction_NoneImpl _value,
+      $Res Function(_$Satisfaction_NoneImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? msg = null,
+  }) {
+    return _then(_$Satisfaction_NoneImpl(
+      msg: null == msg
+          ? _value.msg
+          : msg // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Satisfaction_NoneImpl extends Satisfaction_None {
+  const _$Satisfaction_NoneImpl({required this.msg}) : super._();
+
+  @override
+  final String msg;
+
+  @override
+  String toString() {
+    return 'Satisfaction.none(msg: $msg)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Satisfaction_NoneImpl &&
+            (identical(other.msg, msg) || other.msg == msg));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, msg);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Satisfaction_NoneImplCopyWith<_$Satisfaction_NoneImpl> get copyWith =>
+      __$$Satisfaction_NoneImplCopyWithImpl<_$Satisfaction_NoneImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<int, List<Condition>> conditions)
+        partial,
+    required TResult Function(BigInt n, BigInt m, Uint64List items,
+            bool? sorted, Map<Uint32List, List<Condition>> conditions)
+        partialComplete,
+    required TResult Function(Condition condition) complete,
+    required TResult Function(String msg) none,
+  }) {
+    return none(msg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult? Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult? Function(Condition condition)? complete,
+    TResult? Function(String msg)? none,
+  }) {
+    return none?.call(msg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<int, List<Condition>> conditions)?
+        partial,
+    TResult Function(BigInt n, BigInt m, Uint64List items, bool? sorted,
+            Map<Uint32List, List<Condition>> conditions)?
+        partialComplete,
+    TResult Function(Condition condition)? complete,
+    TResult Function(String msg)? none,
+    required TResult orElse(),
+  }) {
+    if (none != null) {
+      return none(msg);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Satisfaction_Partial value) partial,
+    required TResult Function(Satisfaction_PartialComplete value)
+        partialComplete,
+    required TResult Function(Satisfaction_Complete value) complete,
+    required TResult Function(Satisfaction_None value) none,
+  }) {
+    return none(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Satisfaction_Partial value)? partial,
+    TResult? Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult? Function(Satisfaction_Complete value)? complete,
+    TResult? Function(Satisfaction_None value)? none,
+  }) {
+    return none?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Satisfaction_Partial value)? partial,
+    TResult Function(Satisfaction_PartialComplete value)? partialComplete,
+    TResult Function(Satisfaction_Complete value)? complete,
+    TResult Function(Satisfaction_None value)? none,
+    required TResult orElse(),
+  }) {
+    if (none != null) {
+      return none(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Satisfaction_None extends Satisfaction {
+  const factory Satisfaction_None({required final String msg}) =
+      _$Satisfaction_NoneImpl;
+  const Satisfaction_None._() : super._();
+
+  String get msg;
+  @JsonKey(ignore: true)
+  _$$Satisfaction_NoneImplCopyWith<_$Satisfaction_NoneImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SatisfiableItem {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SatisfiableItemCopyWith<$Res> {
+  factory $SatisfiableItemCopyWith(
+          SatisfiableItem value, $Res Function(SatisfiableItem) then) =
+      _$SatisfiableItemCopyWithImpl<$Res, SatisfiableItem>;
+}
+
+/// @nodoc
+class _$SatisfiableItemCopyWithImpl<$Res, $Val extends SatisfiableItem>
+    implements $SatisfiableItemCopyWith<$Res> {
+  _$SatisfiableItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_EcdsaSignatureImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_EcdsaSignatureImplCopyWith(
+          _$SatisfiableItem_EcdsaSignatureImpl value,
+          $Res Function(_$SatisfiableItem_EcdsaSignatureImpl) then) =
+      __$$SatisfiableItem_EcdsaSignatureImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({PkOrF key});
+
+  $PkOrFCopyWith<$Res> get key;
+}
+
+/// @nodoc
+class __$$SatisfiableItem_EcdsaSignatureImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_EcdsaSignatureImpl>
+    implements _$$SatisfiableItem_EcdsaSignatureImplCopyWith<$Res> {
+  __$$SatisfiableItem_EcdsaSignatureImplCopyWithImpl(
+      _$SatisfiableItem_EcdsaSignatureImpl _value,
+      $Res Function(_$SatisfiableItem_EcdsaSignatureImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = null,
+  }) {
+    return _then(_$SatisfiableItem_EcdsaSignatureImpl(
+      key: null == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as PkOrF,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PkOrFCopyWith<$Res> get key {
+    return $PkOrFCopyWith<$Res>(_value.key, (value) {
+      return _then(_value.copyWith(key: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_EcdsaSignatureImpl
+    extends SatisfiableItem_EcdsaSignature {
+  const _$SatisfiableItem_EcdsaSignatureImpl({required this.key}) : super._();
+
+  @override
+  final PkOrF key;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.ecdsaSignature(key: $key)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_EcdsaSignatureImpl &&
+            (identical(other.key, key) || other.key == key));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, key);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_EcdsaSignatureImplCopyWith<
+          _$SatisfiableItem_EcdsaSignatureImpl>
+      get copyWith => __$$SatisfiableItem_EcdsaSignatureImplCopyWithImpl<
+          _$SatisfiableItem_EcdsaSignatureImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return ecdsaSignature(key);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return ecdsaSignature?.call(key);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (ecdsaSignature != null) {
+      return ecdsaSignature(key);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return ecdsaSignature(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return ecdsaSignature?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (ecdsaSignature != null) {
+      return ecdsaSignature(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_EcdsaSignature extends SatisfiableItem {
+  const factory SatisfiableItem_EcdsaSignature({required final PkOrF key}) =
+      _$SatisfiableItem_EcdsaSignatureImpl;
+  const SatisfiableItem_EcdsaSignature._() : super._();
+
+  PkOrF get key;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_EcdsaSignatureImplCopyWith<
+          _$SatisfiableItem_EcdsaSignatureImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_SchnorrSignatureImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_SchnorrSignatureImplCopyWith(
+          _$SatisfiableItem_SchnorrSignatureImpl value,
+          $Res Function(_$SatisfiableItem_SchnorrSignatureImpl) then) =
+      __$$SatisfiableItem_SchnorrSignatureImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({PkOrF key});
+
+  $PkOrFCopyWith<$Res> get key;
+}
+
+/// @nodoc
+class __$$SatisfiableItem_SchnorrSignatureImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_SchnorrSignatureImpl>
+    implements _$$SatisfiableItem_SchnorrSignatureImplCopyWith<$Res> {
+  __$$SatisfiableItem_SchnorrSignatureImplCopyWithImpl(
+      _$SatisfiableItem_SchnorrSignatureImpl _value,
+      $Res Function(_$SatisfiableItem_SchnorrSignatureImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = null,
+  }) {
+    return _then(_$SatisfiableItem_SchnorrSignatureImpl(
+      key: null == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as PkOrF,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PkOrFCopyWith<$Res> get key {
+    return $PkOrFCopyWith<$Res>(_value.key, (value) {
+      return _then(_value.copyWith(key: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_SchnorrSignatureImpl
+    extends SatisfiableItem_SchnorrSignature {
+  const _$SatisfiableItem_SchnorrSignatureImpl({required this.key}) : super._();
+
+  @override
+  final PkOrF key;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.schnorrSignature(key: $key)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_SchnorrSignatureImpl &&
+            (identical(other.key, key) || other.key == key));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, key);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_SchnorrSignatureImplCopyWith<
+          _$SatisfiableItem_SchnorrSignatureImpl>
+      get copyWith => __$$SatisfiableItem_SchnorrSignatureImplCopyWithImpl<
+          _$SatisfiableItem_SchnorrSignatureImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return schnorrSignature(key);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return schnorrSignature?.call(key);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (schnorrSignature != null) {
+      return schnorrSignature(key);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return schnorrSignature(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return schnorrSignature?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (schnorrSignature != null) {
+      return schnorrSignature(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_SchnorrSignature extends SatisfiableItem {
+  const factory SatisfiableItem_SchnorrSignature({required final PkOrF key}) =
+      _$SatisfiableItem_SchnorrSignatureImpl;
+  const SatisfiableItem_SchnorrSignature._() : super._();
+
+  PkOrF get key;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_SchnorrSignatureImplCopyWith<
+          _$SatisfiableItem_SchnorrSignatureImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_Sha256PreimageImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_Sha256PreimageImplCopyWith(
+          _$SatisfiableItem_Sha256PreimageImpl value,
+          $Res Function(_$SatisfiableItem_Sha256PreimageImpl) then) =
+      __$$SatisfiableItem_Sha256PreimageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String hash});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_Sha256PreimageImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_Sha256PreimageImpl>
+    implements _$$SatisfiableItem_Sha256PreimageImplCopyWith<$Res> {
+  __$$SatisfiableItem_Sha256PreimageImplCopyWithImpl(
+      _$SatisfiableItem_Sha256PreimageImpl _value,
+      $Res Function(_$SatisfiableItem_Sha256PreimageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hash = null,
+  }) {
+    return _then(_$SatisfiableItem_Sha256PreimageImpl(
+      hash: null == hash
+          ? _value.hash
+          : hash // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_Sha256PreimageImpl
+    extends SatisfiableItem_Sha256Preimage {
+  const _$SatisfiableItem_Sha256PreimageImpl({required this.hash}) : super._();
+
+  @override
+  final String hash;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.sha256Preimage(hash: $hash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_Sha256PreimageImpl &&
+            (identical(other.hash, hash) || other.hash == hash));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, hash);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_Sha256PreimageImplCopyWith<
+          _$SatisfiableItem_Sha256PreimageImpl>
+      get copyWith => __$$SatisfiableItem_Sha256PreimageImplCopyWithImpl<
+          _$SatisfiableItem_Sha256PreimageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return sha256Preimage(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return sha256Preimage?.call(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (sha256Preimage != null) {
+      return sha256Preimage(hash);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return sha256Preimage(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return sha256Preimage?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (sha256Preimage != null) {
+      return sha256Preimage(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Sha256Preimage extends SatisfiableItem {
+  const factory SatisfiableItem_Sha256Preimage({required final String hash}) =
+      _$SatisfiableItem_Sha256PreimageImpl;
+  const SatisfiableItem_Sha256Preimage._() : super._();
+
+  String get hash;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_Sha256PreimageImplCopyWith<
+          _$SatisfiableItem_Sha256PreimageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_Hash256PreimageImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_Hash256PreimageImplCopyWith(
+          _$SatisfiableItem_Hash256PreimageImpl value,
+          $Res Function(_$SatisfiableItem_Hash256PreimageImpl) then) =
+      __$$SatisfiableItem_Hash256PreimageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String hash});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_Hash256PreimageImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_Hash256PreimageImpl>
+    implements _$$SatisfiableItem_Hash256PreimageImplCopyWith<$Res> {
+  __$$SatisfiableItem_Hash256PreimageImplCopyWithImpl(
+      _$SatisfiableItem_Hash256PreimageImpl _value,
+      $Res Function(_$SatisfiableItem_Hash256PreimageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hash = null,
+  }) {
+    return _then(_$SatisfiableItem_Hash256PreimageImpl(
+      hash: null == hash
+          ? _value.hash
+          : hash // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_Hash256PreimageImpl
+    extends SatisfiableItem_Hash256Preimage {
+  const _$SatisfiableItem_Hash256PreimageImpl({required this.hash}) : super._();
+
+  @override
+  final String hash;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.hash256Preimage(hash: $hash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_Hash256PreimageImpl &&
+            (identical(other.hash, hash) || other.hash == hash));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, hash);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_Hash256PreimageImplCopyWith<
+          _$SatisfiableItem_Hash256PreimageImpl>
+      get copyWith => __$$SatisfiableItem_Hash256PreimageImplCopyWithImpl<
+          _$SatisfiableItem_Hash256PreimageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return hash256Preimage(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return hash256Preimage?.call(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (hash256Preimage != null) {
+      return hash256Preimage(hash);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return hash256Preimage(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return hash256Preimage?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (hash256Preimage != null) {
+      return hash256Preimage(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Hash256Preimage extends SatisfiableItem {
+  const factory SatisfiableItem_Hash256Preimage({required final String hash}) =
+      _$SatisfiableItem_Hash256PreimageImpl;
+  const SatisfiableItem_Hash256Preimage._() : super._();
+
+  String get hash;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_Hash256PreimageImplCopyWith<
+          _$SatisfiableItem_Hash256PreimageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_Ripemd160PreimageImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_Ripemd160PreimageImplCopyWith(
+          _$SatisfiableItem_Ripemd160PreimageImpl value,
+          $Res Function(_$SatisfiableItem_Ripemd160PreimageImpl) then) =
+      __$$SatisfiableItem_Ripemd160PreimageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String hash});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_Ripemd160PreimageImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_Ripemd160PreimageImpl>
+    implements _$$SatisfiableItem_Ripemd160PreimageImplCopyWith<$Res> {
+  __$$SatisfiableItem_Ripemd160PreimageImplCopyWithImpl(
+      _$SatisfiableItem_Ripemd160PreimageImpl _value,
+      $Res Function(_$SatisfiableItem_Ripemd160PreimageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hash = null,
+  }) {
+    return _then(_$SatisfiableItem_Ripemd160PreimageImpl(
+      hash: null == hash
+          ? _value.hash
+          : hash // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_Ripemd160PreimageImpl
+    extends SatisfiableItem_Ripemd160Preimage {
+  const _$SatisfiableItem_Ripemd160PreimageImpl({required this.hash})
+      : super._();
+
+  @override
+  final String hash;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.ripemd160Preimage(hash: $hash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_Ripemd160PreimageImpl &&
+            (identical(other.hash, hash) || other.hash == hash));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, hash);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_Ripemd160PreimageImplCopyWith<
+          _$SatisfiableItem_Ripemd160PreimageImpl>
+      get copyWith => __$$SatisfiableItem_Ripemd160PreimageImplCopyWithImpl<
+          _$SatisfiableItem_Ripemd160PreimageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return ripemd160Preimage(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return ripemd160Preimage?.call(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (ripemd160Preimage != null) {
+      return ripemd160Preimage(hash);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return ripemd160Preimage(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return ripemd160Preimage?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (ripemd160Preimage != null) {
+      return ripemd160Preimage(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Ripemd160Preimage extends SatisfiableItem {
+  const factory SatisfiableItem_Ripemd160Preimage(
+      {required final String hash}) = _$SatisfiableItem_Ripemd160PreimageImpl;
+  const SatisfiableItem_Ripemd160Preimage._() : super._();
+
+  String get hash;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_Ripemd160PreimageImplCopyWith<
+          _$SatisfiableItem_Ripemd160PreimageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_Hash160PreimageImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_Hash160PreimageImplCopyWith(
+          _$SatisfiableItem_Hash160PreimageImpl value,
+          $Res Function(_$SatisfiableItem_Hash160PreimageImpl) then) =
+      __$$SatisfiableItem_Hash160PreimageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String hash});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_Hash160PreimageImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_Hash160PreimageImpl>
+    implements _$$SatisfiableItem_Hash160PreimageImplCopyWith<$Res> {
+  __$$SatisfiableItem_Hash160PreimageImplCopyWithImpl(
+      _$SatisfiableItem_Hash160PreimageImpl _value,
+      $Res Function(_$SatisfiableItem_Hash160PreimageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hash = null,
+  }) {
+    return _then(_$SatisfiableItem_Hash160PreimageImpl(
+      hash: null == hash
+          ? _value.hash
+          : hash // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_Hash160PreimageImpl
+    extends SatisfiableItem_Hash160Preimage {
+  const _$SatisfiableItem_Hash160PreimageImpl({required this.hash}) : super._();
+
+  @override
+  final String hash;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.hash160Preimage(hash: $hash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_Hash160PreimageImpl &&
+            (identical(other.hash, hash) || other.hash == hash));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, hash);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_Hash160PreimageImplCopyWith<
+          _$SatisfiableItem_Hash160PreimageImpl>
+      get copyWith => __$$SatisfiableItem_Hash160PreimageImplCopyWithImpl<
+          _$SatisfiableItem_Hash160PreimageImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return hash160Preimage(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return hash160Preimage?.call(hash);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (hash160Preimage != null) {
+      return hash160Preimage(hash);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return hash160Preimage(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return hash160Preimage?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (hash160Preimage != null) {
+      return hash160Preimage(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Hash160Preimage extends SatisfiableItem {
+  const factory SatisfiableItem_Hash160Preimage({required final String hash}) =
+      _$SatisfiableItem_Hash160PreimageImpl;
+  const SatisfiableItem_Hash160Preimage._() : super._();
+
+  String get hash;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_Hash160PreimageImplCopyWith<
+          _$SatisfiableItem_Hash160PreimageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_AbsoluteTimelockImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_AbsoluteTimelockImplCopyWith(
+          _$SatisfiableItem_AbsoluteTimelockImpl value,
+          $Res Function(_$SatisfiableItem_AbsoluteTimelockImpl) then) =
+      __$$SatisfiableItem_AbsoluteTimelockImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({LockTime value});
+
+  $LockTimeCopyWith<$Res> get value;
+}
+
+/// @nodoc
+class __$$SatisfiableItem_AbsoluteTimelockImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_AbsoluteTimelockImpl>
+    implements _$$SatisfiableItem_AbsoluteTimelockImplCopyWith<$Res> {
+  __$$SatisfiableItem_AbsoluteTimelockImplCopyWithImpl(
+      _$SatisfiableItem_AbsoluteTimelockImpl _value,
+      $Res Function(_$SatisfiableItem_AbsoluteTimelockImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$SatisfiableItem_AbsoluteTimelockImpl(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as LockTime,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LockTimeCopyWith<$Res> get value {
+    return $LockTimeCopyWith<$Res>(_value.value, (value) {
+      return _then(_value.copyWith(value: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_AbsoluteTimelockImpl
+    extends SatisfiableItem_AbsoluteTimelock {
+  const _$SatisfiableItem_AbsoluteTimelockImpl({required this.value})
+      : super._();
+
+  @override
+  final LockTime value;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.absoluteTimelock(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_AbsoluteTimelockImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_AbsoluteTimelockImplCopyWith<
+          _$SatisfiableItem_AbsoluteTimelockImpl>
+      get copyWith => __$$SatisfiableItem_AbsoluteTimelockImplCopyWithImpl<
+          _$SatisfiableItem_AbsoluteTimelockImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return absoluteTimelock(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return absoluteTimelock?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (absoluteTimelock != null) {
+      return absoluteTimelock(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return absoluteTimelock(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return absoluteTimelock?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (absoluteTimelock != null) {
+      return absoluteTimelock(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_AbsoluteTimelock extends SatisfiableItem {
+  const factory SatisfiableItem_AbsoluteTimelock(
+      {required final LockTime value}) = _$SatisfiableItem_AbsoluteTimelockImpl;
+  const SatisfiableItem_AbsoluteTimelock._() : super._();
+
+  LockTime get value;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_AbsoluteTimelockImplCopyWith<
+          _$SatisfiableItem_AbsoluteTimelockImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_RelativeTimelockImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_RelativeTimelockImplCopyWith(
+          _$SatisfiableItem_RelativeTimelockImpl value,
+          $Res Function(_$SatisfiableItem_RelativeTimelockImpl) then) =
+      __$$SatisfiableItem_RelativeTimelockImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int value});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_RelativeTimelockImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res,
+        _$SatisfiableItem_RelativeTimelockImpl>
+    implements _$$SatisfiableItem_RelativeTimelockImplCopyWith<$Res> {
+  __$$SatisfiableItem_RelativeTimelockImplCopyWithImpl(
+      _$SatisfiableItem_RelativeTimelockImpl _value,
+      $Res Function(_$SatisfiableItem_RelativeTimelockImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$SatisfiableItem_RelativeTimelockImpl(
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_RelativeTimelockImpl
+    extends SatisfiableItem_RelativeTimelock {
+  const _$SatisfiableItem_RelativeTimelockImpl({required this.value})
+      : super._();
+
+  @override
+  final int value;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.relativeTimelock(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_RelativeTimelockImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_RelativeTimelockImplCopyWith<
+          _$SatisfiableItem_RelativeTimelockImpl>
+      get copyWith => __$$SatisfiableItem_RelativeTimelockImplCopyWithImpl<
+          _$SatisfiableItem_RelativeTimelockImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return relativeTimelock(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return relativeTimelock?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (relativeTimelock != null) {
+      return relativeTimelock(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return relativeTimelock(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return relativeTimelock?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (relativeTimelock != null) {
+      return relativeTimelock(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_RelativeTimelock extends SatisfiableItem {
+  const factory SatisfiableItem_RelativeTimelock({required final int value}) =
+      _$SatisfiableItem_RelativeTimelockImpl;
+  const SatisfiableItem_RelativeTimelock._() : super._();
+
+  int get value;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_RelativeTimelockImplCopyWith<
+          _$SatisfiableItem_RelativeTimelockImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_MultisigImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_MultisigImplCopyWith(
+          _$SatisfiableItem_MultisigImpl value,
+          $Res Function(_$SatisfiableItem_MultisigImpl) then) =
+      __$$SatisfiableItem_MultisigImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<PkOrF> keys, BigInt threshold});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_MultisigImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res, _$SatisfiableItem_MultisigImpl>
+    implements _$$SatisfiableItem_MultisigImplCopyWith<$Res> {
+  __$$SatisfiableItem_MultisigImplCopyWithImpl(
+      _$SatisfiableItem_MultisigImpl _value,
+      $Res Function(_$SatisfiableItem_MultisigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keys = null,
+    Object? threshold = null,
+  }) {
+    return _then(_$SatisfiableItem_MultisigImpl(
+      keys: null == keys
+          ? _value._keys
+          : keys // ignore: cast_nullable_to_non_nullable
+              as List<PkOrF>,
+      threshold: null == threshold
+          ? _value.threshold
+          : threshold // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_MultisigImpl extends SatisfiableItem_Multisig {
+  const _$SatisfiableItem_MultisigImpl(
+      {required final List<PkOrF> keys, required this.threshold})
+      : _keys = keys,
+        super._();
+
+  final List<PkOrF> _keys;
+  @override
+  List<PkOrF> get keys {
+    if (_keys is EqualUnmodifiableListView) return _keys;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_keys);
+  }
+
+  @override
+  final BigInt threshold;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.multisig(keys: $keys, threshold: $threshold)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_MultisigImpl &&
+            const DeepCollectionEquality().equals(other._keys, _keys) &&
+            (identical(other.threshold, threshold) ||
+                other.threshold == threshold));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_keys), threshold);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_MultisigImplCopyWith<_$SatisfiableItem_MultisigImpl>
+      get copyWith => __$$SatisfiableItem_MultisigImplCopyWithImpl<
+          _$SatisfiableItem_MultisigImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return multisig(keys, threshold);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return multisig?.call(keys, threshold);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (multisig != null) {
+      return multisig(keys, threshold);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return multisig(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return multisig?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (multisig != null) {
+      return multisig(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Multisig extends SatisfiableItem {
+  const factory SatisfiableItem_Multisig(
+      {required final List<PkOrF> keys,
+      required final BigInt threshold}) = _$SatisfiableItem_MultisigImpl;
+  const SatisfiableItem_Multisig._() : super._();
+
+  List<PkOrF> get keys;
+  BigInt get threshold;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_MultisigImplCopyWith<_$SatisfiableItem_MultisigImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SatisfiableItem_ThreshImplCopyWith<$Res> {
+  factory _$$SatisfiableItem_ThreshImplCopyWith(
+          _$SatisfiableItem_ThreshImpl value,
+          $Res Function(_$SatisfiableItem_ThreshImpl) then) =
+      __$$SatisfiableItem_ThreshImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<BdkPolicy> items, BigInt threshold});
+}
+
+/// @nodoc
+class __$$SatisfiableItem_ThreshImplCopyWithImpl<$Res>
+    extends _$SatisfiableItemCopyWithImpl<$Res, _$SatisfiableItem_ThreshImpl>
+    implements _$$SatisfiableItem_ThreshImplCopyWith<$Res> {
+  __$$SatisfiableItem_ThreshImplCopyWithImpl(
+      _$SatisfiableItem_ThreshImpl _value,
+      $Res Function(_$SatisfiableItem_ThreshImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? items = null,
+    Object? threshold = null,
+  }) {
+    return _then(_$SatisfiableItem_ThreshImpl(
+      items: null == items
+          ? _value._items
+          : items // ignore: cast_nullable_to_non_nullable
+              as List<BdkPolicy>,
+      threshold: null == threshold
+          ? _value.threshold
+          : threshold // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SatisfiableItem_ThreshImpl extends SatisfiableItem_Thresh {
+  const _$SatisfiableItem_ThreshImpl(
+      {required final List<BdkPolicy> items, required this.threshold})
+      : _items = items,
+        super._();
+
+  final List<BdkPolicy> _items;
+  @override
+  List<BdkPolicy> get items {
+    if (_items is EqualUnmodifiableListView) return _items;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_items);
+  }
+
+  @override
+  final BigInt threshold;
+
+  @override
+  String toString() {
+    return 'SatisfiableItem.thresh(items: $items, threshold: $threshold)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SatisfiableItem_ThreshImpl &&
+            const DeepCollectionEquality().equals(other._items, _items) &&
+            (identical(other.threshold, threshold) ||
+                other.threshold == threshold));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_items), threshold);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SatisfiableItem_ThreshImplCopyWith<_$SatisfiableItem_ThreshImpl>
+      get copyWith => __$$SatisfiableItem_ThreshImplCopyWithImpl<
+          _$SatisfiableItem_ThreshImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(PkOrF key) ecdsaSignature,
+    required TResult Function(PkOrF key) schnorrSignature,
+    required TResult Function(String hash) sha256Preimage,
+    required TResult Function(String hash) hash256Preimage,
+    required TResult Function(String hash) ripemd160Preimage,
+    required TResult Function(String hash) hash160Preimage,
+    required TResult Function(LockTime value) absoluteTimelock,
+    required TResult Function(int value) relativeTimelock,
+    required TResult Function(List<PkOrF> keys, BigInt threshold) multisig,
+    required TResult Function(List<BdkPolicy> items, BigInt threshold) thresh,
+  }) {
+    return thresh(items, threshold);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(PkOrF key)? ecdsaSignature,
+    TResult? Function(PkOrF key)? schnorrSignature,
+    TResult? Function(String hash)? sha256Preimage,
+    TResult? Function(String hash)? hash256Preimage,
+    TResult? Function(String hash)? ripemd160Preimage,
+    TResult? Function(String hash)? hash160Preimage,
+    TResult? Function(LockTime value)? absoluteTimelock,
+    TResult? Function(int value)? relativeTimelock,
+    TResult? Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult? Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+  }) {
+    return thresh?.call(items, threshold);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(PkOrF key)? ecdsaSignature,
+    TResult Function(PkOrF key)? schnorrSignature,
+    TResult Function(String hash)? sha256Preimage,
+    TResult Function(String hash)? hash256Preimage,
+    TResult Function(String hash)? ripemd160Preimage,
+    TResult Function(String hash)? hash160Preimage,
+    TResult Function(LockTime value)? absoluteTimelock,
+    TResult Function(int value)? relativeTimelock,
+    TResult Function(List<PkOrF> keys, BigInt threshold)? multisig,
+    TResult Function(List<BdkPolicy> items, BigInt threshold)? thresh,
+    required TResult orElse(),
+  }) {
+    if (thresh != null) {
+      return thresh(items, threshold);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SatisfiableItem_EcdsaSignature value)
+        ecdsaSignature,
+    required TResult Function(SatisfiableItem_SchnorrSignature value)
+        schnorrSignature,
+    required TResult Function(SatisfiableItem_Sha256Preimage value)
+        sha256Preimage,
+    required TResult Function(SatisfiableItem_Hash256Preimage value)
+        hash256Preimage,
+    required TResult Function(SatisfiableItem_Ripemd160Preimage value)
+        ripemd160Preimage,
+    required TResult Function(SatisfiableItem_Hash160Preimage value)
+        hash160Preimage,
+    required TResult Function(SatisfiableItem_AbsoluteTimelock value)
+        absoluteTimelock,
+    required TResult Function(SatisfiableItem_RelativeTimelock value)
+        relativeTimelock,
+    required TResult Function(SatisfiableItem_Multisig value) multisig,
+    required TResult Function(SatisfiableItem_Thresh value) thresh,
+  }) {
+    return thresh(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult? Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult? Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult? Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult? Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult? Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult? Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult? Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult? Function(SatisfiableItem_Multisig value)? multisig,
+    TResult? Function(SatisfiableItem_Thresh value)? thresh,
+  }) {
+    return thresh?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SatisfiableItem_EcdsaSignature value)? ecdsaSignature,
+    TResult Function(SatisfiableItem_SchnorrSignature value)? schnorrSignature,
+    TResult Function(SatisfiableItem_Sha256Preimage value)? sha256Preimage,
+    TResult Function(SatisfiableItem_Hash256Preimage value)? hash256Preimage,
+    TResult Function(SatisfiableItem_Ripemd160Preimage value)?
+        ripemd160Preimage,
+    TResult Function(SatisfiableItem_Hash160Preimage value)? hash160Preimage,
+    TResult Function(SatisfiableItem_AbsoluteTimelock value)? absoluteTimelock,
+    TResult Function(SatisfiableItem_RelativeTimelock value)? relativeTimelock,
+    TResult Function(SatisfiableItem_Multisig value)? multisig,
+    TResult Function(SatisfiableItem_Thresh value)? thresh,
+    required TResult orElse(),
+  }) {
+    if (thresh != null) {
+      return thresh(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SatisfiableItem_Thresh extends SatisfiableItem {
+  const factory SatisfiableItem_Thresh(
+      {required final List<BdkPolicy> items,
+      required final BigInt threshold}) = _$SatisfiableItem_ThreshImpl;
+  const SatisfiableItem_Thresh._() : super._();
+
+  List<BdkPolicy> get items;
+  BigInt get threshold;
+  @JsonKey(ignore: true)
+  _$$SatisfiableItem_ThreshImplCopyWith<_$SatisfiableItem_ThreshImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/generated/api/wallet.dart
+++ b/lib/src/generated/api/wallet.dart
@@ -42,6 +42,8 @@ Future<(BdkPsbt, TransactionDetails)> txBuilderFinish(
         required bool drainWallet,
         BdkScriptBuf? drainTo,
         RbfValue? rbf,
+        Map<String, Uint64List>? internalPolicyPath,
+        Map<String, Uint64List>? externalPolicyPath,
         required List<int> data}) =>
     core.instance.api.crateApiWalletTxBuilderFinish(
         wallet: wallet,
@@ -56,6 +58,8 @@ Future<(BdkPsbt, TransactionDetails)> txBuilderFinish(
         drainWallet: drainWallet,
         drainTo: drainTo,
         rbf: rbf,
+        internalPolicyPath: internalPolicyPath,
+        externalPolicyPath: externalPolicyPath,
         data: data);
 
 class BdkWallet {
@@ -139,6 +143,11 @@ class BdkWallet {
           changeDescriptor: changeDescriptor,
           network: network,
           databaseConfig: databaseConfig);
+
+  static BdkPolicy? policies(
+          {required BdkWallet ptr, required KeychainKind keychain}) =>
+      core.instance.api
+          .crateApiWalletBdkWalletPolicies(ptr: ptr, keychain: keychain);
 
   /// Sign a transaction with all the wallet's signers. This function returns an encapsulated bool that
   /// has the value true if the PSBT was finalized, or false otherwise.

--- a/lib/src/generated/api/wallet.dart
+++ b/lib/src/generated/api/wallet.dart
@@ -42,8 +42,8 @@ Future<(BdkPsbt, TransactionDetails)> txBuilderFinish(
         required bool drainWallet,
         BdkScriptBuf? drainTo,
         RbfValue? rbf,
-        Map<String, Uint64List>? internalPolicyPath,
-        Map<String, Uint64List>? externalPolicyPath,
+        Map<String, Uint32List>? internalPolicyPath,
+        Map<String, Uint32List>? externalPolicyPath,
         required List<int> data}) =>
     core.instance.api.crateApiWalletTxBuilderFinish(
         wallet: wallet,

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -363,8 +363,8 @@ abstract class coreApi extends BaseApi {
       required bool drainWallet,
       BdkScriptBuf? drainTo,
       RbfValue? rbf,
-      Map<String, Uint64List>? internalPolicyPath,
-      Map<String, Uint64List>? externalPolicyPath,
+      Map<String, Uint32List>? internalPolicyPath,
+      Map<String, Uint32List>? externalPolicyPath,
       required List<int> data});
 
   RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Address;
@@ -2755,8 +2755,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       required bool drainWallet,
       BdkScriptBuf? drainTo,
       RbfValue? rbf,
-      Map<String, Uint64List>? internalPolicyPath,
-      Map<String, Uint64List>? externalPolicyPath,
+      Map<String, Uint32List>? internalPolicyPath,
+      Map<String, Uint32List>? externalPolicyPath,
       required List<int> data}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -2773,10 +2773,10 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         var arg9 = cst_encode_bool(drainWallet);
         var arg10 = cst_encode_opt_box_autoadd_bdk_script_buf(drainTo);
         var arg11 = cst_encode_opt_box_autoadd_rbf_value(rbf);
-        var arg12 = cst_encode_opt_Map_String_list_prim_usize_strict(
-            internalPolicyPath);
-        var arg13 = cst_encode_opt_Map_String_list_prim_usize_strict(
-            externalPolicyPath);
+        var arg12 =
+            cst_encode_opt_Map_String_list_prim_u_32_strict(internalPolicyPath);
+        var arg13 =
+            cst_encode_opt_Map_String_list_prim_u_32_strict(externalPolicyPath);
         var arg14 = cst_encode_list_prim_u_8_loose(data);
         return wire.wire__crate__api__wallet__tx_builder_finish(
             port_,
@@ -2933,11 +2933,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexbdkbitcoinpsbtPartiallySignedTransaction;
 
   @protected
-  Map<String, Uint64List> dco_decode_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List> dco_decode_Map_String_list_prim_u_32_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return Map.fromEntries(
-        dco_decode_list_record_string_list_prim_usize_strict(raw)
+        dco_decode_list_record_string_list_prim_u_32_strict(raw)
             .map((e) => MapEntry(e.$1, e.$2)));
   }
 
@@ -4032,12 +4032,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  Uint64List dco_decode_list_prim_usize_strict(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as Uint64List;
-  }
-
-  @protected
   List<(Uint32List, List<Condition>)>
       dco_decode_list_record_list_prim_u_32_strict_list_condition(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -4047,11 +4041,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  List<(String, Uint64List)>
-      dco_decode_list_record_string_list_prim_usize_strict(dynamic raw) {
+  List<(String, Uint32List)>
+      dco_decode_list_record_string_list_prim_u_32_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>)
-        .map(dco_decode_record_string_list_prim_usize_strict)
+        .map(dco_decode_record_string_list_prim_u_32_strict)
         .toList();
   }
 
@@ -4126,12 +4120,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  Map<String, Uint64List>? dco_decode_opt_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List>? dco_decode_opt_Map_String_list_prim_u_32_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null
         ? null
-        : dco_decode_Map_String_list_prim_usize_strict(raw);
+        : dco_decode_Map_String_list_prim_u_32_strict(raw);
   }
 
   @protected
@@ -4389,7 +4383,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  (String, Uint64List) dco_decode_record_string_list_prim_usize_strict(
+  (String, Uint32List) dco_decode_record_string_list_prim_u_32_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -4398,7 +4392,7 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     }
     return (
       dco_decode_String(arr[0]),
-      dco_decode_list_prim_usize_strict(arr[1]),
+      dco_decode_list_prim_u_32_strict(arr[1]),
     );
   }
 
@@ -4678,11 +4672,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  Map<String, Uint64List> sse_decode_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List> sse_decode_Map_String_list_prim_u_32_strict(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner =
-        sse_decode_list_record_string_list_prim_usize_strict(deserializer);
+        sse_decode_list_record_string_list_prim_u_32_strict(deserializer);
     return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
   }
 
@@ -5762,13 +5756,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  Uint64List sse_decode_list_prim_usize_strict(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var len_ = sse_decode_i_32(deserializer);
-    return deserializer.buffer.getUint64List(len_);
-  }
-
-  @protected
   List<(Uint32List, List<Condition>)>
       sse_decode_list_record_list_prim_u_32_strict_list_condition(
           SseDeserializer deserializer) {
@@ -5784,15 +5771,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  List<(String, Uint64List)>
-      sse_decode_list_record_string_list_prim_usize_strict(
+  List<(String, Uint32List)>
+      sse_decode_list_record_string_list_prim_u_32_strict(
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     var len_ = sse_decode_i_32(deserializer);
-    var ans_ = <(String, Uint64List)>[];
+    var ans_ = <(String, Uint32List)>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
-      ans_.add(sse_decode_record_string_list_prim_usize_strict(deserializer));
+      ans_.add(sse_decode_record_string_list_prim_u_32_strict(deserializer));
     }
     return ans_;
   }
@@ -5899,12 +5886,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  Map<String, Uint64List>? sse_decode_opt_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List>? sse_decode_opt_Map_String_list_prim_u_32_strict(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     if (sse_decode_bool(deserializer)) {
-      return (sse_decode_Map_String_list_prim_usize_strict(deserializer));
+      return (sse_decode_Map_String_list_prim_u_32_strict(deserializer));
     } else {
       return null;
     }
@@ -6243,11 +6230,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  (String, Uint64List) sse_decode_record_string_list_prim_usize_strict(
+  (String, Uint32List) sse_decode_record_string_list_prim_u_32_strict(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_field0 = sse_decode_String(deserializer);
-    var var_field1 = sse_decode_list_prim_usize_strict(deserializer);
+    var var_field1 = sse_decode_list_prim_u_32_strict(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -6678,10 +6665,10 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_Map_String_list_prim_usize_strict(
-      Map<String, Uint64List> self, SseSerializer serializer) {
+  void sse_encode_Map_String_list_prim_u_32_strict(
+      Map<String, Uint32List> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_list_record_string_list_prim_usize_strict(
+    sse_encode_list_record_string_list_prim_u_32_strict(
         self.entries.map((e) => (e.key, e.value)).toList(), serializer);
   }
 
@@ -7723,14 +7710,6 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_list_prim_usize_strict(
-      Uint64List self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.length, serializer);
-    serializer.buffer.putUint64List(self);
-  }
-
-  @protected
   void sse_encode_list_record_list_prim_u_32_strict_list_condition(
       List<(Uint32List, List<Condition>)> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -7741,12 +7720,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_list_record_string_list_prim_usize_strict(
-      List<(String, Uint64List)> self, SseSerializer serializer) {
+  void sse_encode_list_record_string_list_prim_u_32_strict(
+      List<(String, Uint32List)> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
-      sse_encode_record_string_list_prim_usize_strict(item, serializer);
+      sse_encode_record_string_list_prim_u_32_strict(item, serializer);
     }
   }
 
@@ -7829,13 +7808,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_opt_Map_String_list_prim_usize_strict(
-      Map<String, Uint64List>? self, SseSerializer serializer) {
+  void sse_encode_opt_Map_String_list_prim_u_32_strict(
+      Map<String, Uint32List>? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     sse_encode_bool(self != null, serializer);
     if (self != null) {
-      sse_encode_Map_String_list_prim_usize_strict(self, serializer);
+      sse_encode_Map_String_list_prim_u_32_strict(self, serializer);
     }
   }
 
@@ -8144,11 +8123,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
-  void sse_encode_record_string_list_prim_usize_strict(
-      (String, Uint64List) self, SseSerializer serializer) {
+  void sse_encode_record_string_list_prim_u_32_strict(
+      (String, Uint32List) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.$1, serializer);
-    sse_encode_list_prim_usize_strict(self.$2, serializer);
+    sse_encode_list_prim_u_32_strict(self.$2, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -62,7 +62,7 @@ class core extends BaseEntrypoint<coreApi, coreApiImpl, coreWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => 1897842111;
+  int get rustContentHash => -321771070;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -232,6 +232,18 @@ abstract class coreApi extends BaseApi {
 
   String crateApiTypesBdkAddressToQrUri({required BdkAddress that});
 
+  String crateApiTypesBdkPolicyAsString({required BdkPolicy that});
+
+  Satisfaction crateApiTypesBdkPolicyContribution({required BdkPolicy that});
+
+  String crateApiTypesBdkPolicyId({required BdkPolicy that});
+
+  SatisfiableItem crateApiTypesBdkPolicyItem({required BdkPolicy that});
+
+  bool crateApiTypesBdkPolicyRequiresPath({required BdkPolicy that});
+
+  Satisfaction crateApiTypesBdkPolicySatisfaction({required BdkPolicy that});
+
   String crateApiTypesBdkScriptBufAsString({required BdkScriptBuf that});
 
   BdkScriptBuf crateApiTypesBdkScriptBufEmpty();
@@ -319,6 +331,9 @@ abstract class coreApi extends BaseApi {
       required Network network,
       required DatabaseConfig databaseConfig});
 
+  BdkPolicy? crateApiWalletBdkWalletPolicies(
+      {required BdkWallet ptr, required KeychainKind keychain});
+
   Future<bool> crateApiWalletBdkWalletSign(
       {required BdkWallet ptr,
       required BdkPsbt psbt,
@@ -348,6 +363,8 @@ abstract class coreApi extends BaseApi {
       required bool drainWallet,
       BdkScriptBuf? drainTo,
       RbfValue? rbf,
+      Map<String, Uint64List>? internalPolicyPath,
+      Map<String, Uint64List>? externalPolicyPath,
       required List<int> data});
 
   RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Address;
@@ -382,6 +399,12 @@ abstract class coreApi extends BaseApi {
 
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_ExtendedDescriptorPtr;
+
+  RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Policy;
+
+  RustArcDecrementStrongCountFnType get rust_arc_decrement_strong_count_Policy;
+
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_PolicyPtr;
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_DescriptorPublicKey;
@@ -1748,6 +1771,142 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
+  String crateApiTypesBdkPolicyAsString({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_as_string(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_String,
+        decodeErrorData: dco_decode_bdk_error,
+      ),
+      constMeta: kCrateApiTypesBdkPolicyAsStringConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicyAsStringConstMeta =>
+      const TaskConstMeta(
+        debugName: "bdk_policy_as_string",
+        argNames: ["that"],
+      );
+
+  @override
+  Satisfaction crateApiTypesBdkPolicyContribution({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_contribution(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_satisfaction,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTypesBdkPolicyContributionConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicyContributionConstMeta =>
+      const TaskConstMeta(
+        debugName: "bdk_policy_contribution",
+        argNames: ["that"],
+      );
+
+  @override
+  String crateApiTypesBdkPolicyId({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_id(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTypesBdkPolicyIdConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicyIdConstMeta => const TaskConstMeta(
+        debugName: "bdk_policy_id",
+        argNames: ["that"],
+      );
+
+  @override
+  SatisfiableItem crateApiTypesBdkPolicyItem({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_item(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_satisfiable_item,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTypesBdkPolicyItemConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicyItemConstMeta => const TaskConstMeta(
+        debugName: "bdk_policy_item",
+        argNames: ["that"],
+      );
+
+  @override
+  bool crateApiTypesBdkPolicyRequiresPath({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_requires_path(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTypesBdkPolicyRequiresPathConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicyRequiresPathConstMeta =>
+      const TaskConstMeta(
+        debugName: "bdk_policy_requires_path",
+        argNames: ["that"],
+      );
+
+  @override
+  Satisfaction crateApiTypesBdkPolicySatisfaction({required BdkPolicy that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_policy(that);
+        return wire.wire__crate__api__types__bdk_policy_satisfaction(arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_satisfaction,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiTypesBdkPolicySatisfactionConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTypesBdkPolicySatisfactionConstMeta =>
+      const TaskConstMeta(
+        debugName: "bdk_policy_satisfaction",
+        argNames: ["that"],
+      );
+
+  @override
   String crateApiTypesBdkScriptBufAsString({required BdkScriptBuf that}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -2461,6 +2620,31 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       );
 
   @override
+  BdkPolicy? crateApiWalletBdkWalletPolicies(
+      {required BdkWallet ptr, required KeychainKind keychain}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        var arg0 = cst_encode_box_autoadd_bdk_wallet(ptr);
+        var arg1 = cst_encode_keychain_kind(keychain);
+        return wire.wire__crate__api__wallet__bdk_wallet_policies(arg0, arg1);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_opt_box_autoadd_bdk_policy,
+        decodeErrorData: dco_decode_bdk_error,
+      ),
+      constMeta: kCrateApiWalletBdkWalletPoliciesConstMeta,
+      argValues: [ptr, keychain],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiWalletBdkWalletPoliciesConstMeta =>
+      const TaskConstMeta(
+        debugName: "bdk_wallet_policies",
+        argNames: ["ptr", "keychain"],
+      );
+
+  @override
   Future<bool> crateApiWalletBdkWalletSign(
       {required BdkWallet ptr,
       required BdkPsbt psbt,
@@ -2571,6 +2755,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       required bool drainWallet,
       BdkScriptBuf? drainTo,
       RbfValue? rbf,
+      Map<String, Uint64List>? internalPolicyPath,
+      Map<String, Uint64List>? externalPolicyPath,
       required List<int> data}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -2587,7 +2773,11 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         var arg9 = cst_encode_bool(drainWallet);
         var arg10 = cst_encode_opt_box_autoadd_bdk_script_buf(drainTo);
         var arg11 = cst_encode_opt_box_autoadd_rbf_value(rbf);
-        var arg12 = cst_encode_list_prim_u_8_loose(data);
+        var arg12 = cst_encode_opt_Map_String_list_prim_usize_strict(
+            internalPolicyPath);
+        var arg13 = cst_encode_opt_Map_String_list_prim_usize_strict(
+            externalPolicyPath);
+        var arg14 = cst_encode_list_prim_u_8_loose(data);
         return wire.wire__crate__api__wallet__tx_builder_finish(
             port_,
             arg0,
@@ -2602,7 +2792,9 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
             arg9,
             arg10,
             arg11,
-            arg12);
+            arg12,
+            arg13,
+            arg14);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_record_bdk_psbt_transaction_details,
@@ -2622,6 +2814,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         drainWallet,
         drainTo,
         rbf,
+        internalPolicyPath,
+        externalPolicyPath,
         data
       ],
       apiImpl: this,
@@ -2644,6 +2838,8 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           "drainWallet",
           "drainTo",
           "rbf",
+          "internalPolicyPath",
+          "externalPolicyPath",
           "data"
         ],
       );
@@ -2679,6 +2875,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   RustArcDecrementStrongCountFnType
       get rust_arc_decrement_strong_count_ExtendedDescriptor => wire
           .rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor;
+
+  RustArcIncrementStrongCountFnType
+      get rust_arc_increment_strong_count_Policy =>
+          wire.rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy;
+
+  RustArcDecrementStrongCountFnType
+      get rust_arc_decrement_strong_count_Policy =>
+          wire.rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy;
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_DescriptorPublicKey => wire
@@ -2729,6 +2933,31 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexbdkbitcoinpsbtPartiallySignedTransaction;
 
   @protected
+  Map<String, Uint64List> dco_decode_Map_String_list_prim_usize_strict(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(
+        dco_decode_list_record_string_list_prim_usize_strict(raw)
+            .map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
+  Map<Uint32List, List<Condition>>
+      dco_decode_Map_list_prim_u_32_strict_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(
+        dco_decode_list_record_list_prim_u_32_strict_list_condition(raw)
+            .map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
+  Map<int, List<Condition>> dco_decode_Map_u_32_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(dco_decode_list_record_u_32_list_condition(raw)
+        .map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
   Address dco_decode_RustOpaque_bdkbitcoinAddress(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AddressImpl.frbInternalDcoDecode(raw as List<dynamic>);
@@ -2752,6 +2981,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ExtendedDescriptorImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  Policy dco_decode_RustOpaque_bdkdescriptorPolicy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return PolicyImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -3177,6 +3412,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  BdkPolicy dco_decode_bdk_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return BdkPolicy(
+      ptr: dco_decode_RustOpaque_bdkdescriptorPolicy(arr[0]),
+    );
+  }
+
+  @protected
   BdkPsbt dco_decode_bdk_psbt(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3319,6 +3565,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  BdkPolicy dco_decode_box_autoadd_bdk_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_bdk_policy(raw);
+  }
+
+  @protected
   BdkPsbt dco_decode_box_autoadd_bdk_psbt(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_bdk_psbt(raw);
@@ -3352,6 +3604,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   BlockchainConfig dco_decode_box_autoadd_blockchain_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_blockchain_config(raw);
+  }
+
+  @protected
+  bool dco_decode_box_autoadd_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as bool;
+  }
+
+  @protected
+  Condition dco_decode_box_autoadd_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_condition(raw);
   }
 
   @protected
@@ -3418,6 +3682,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   OutPoint dco_decode_box_autoadd_out_point(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_out_point(raw);
+  }
+
+  @protected
+  PkOrF dco_decode_box_autoadd_pk_or_f(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_pk_or_f(raw);
   }
 
   @protected
@@ -3493,6 +3763,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   ChangeSpendPolicy dco_decode_change_spend_policy(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ChangeSpendPolicy.values[raw as int];
+  }
+
+  @protected
+  Condition dco_decode_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return Condition(
+      csv: dco_decode_opt_box_autoadd_u_32(arr[0]),
+      timelock: dco_decode_opt_box_autoadd_lock_time(arr[1]),
+    );
   }
 
   @protected
@@ -3690,6 +3972,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  List<BdkPolicy> dco_decode_list_bdk_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_bdk_policy).toList();
+  }
+
+  @protected
+  List<Condition> dco_decode_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_condition).toList();
+  }
+
+  @protected
   List<Uint8List> dco_decode_list_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_list_prim_u_8_strict).toList();
@@ -3708,6 +4002,24 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  List<PkOrF> dco_decode_list_pk_or_f(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_pk_or_f).toList();
+  }
+
+  @protected
+  Uint32List dco_decode_list_prim_u_32_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Uint32List;
+  }
+
+  @protected
+  Uint64List dco_decode_list_prim_u_64_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeUint64List(raw);
+  }
+
+  @protected
   List<int> dco_decode_list_prim_u_8_loose(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as List<int>;
@@ -3717,6 +4029,39 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
+  }
+
+  @protected
+  Uint64List dco_decode_list_prim_usize_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Uint64List;
+  }
+
+  @protected
+  List<(Uint32List, List<Condition>)>
+      dco_decode_list_record_list_prim_u_32_strict_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_record_list_prim_u_32_strict_list_condition)
+        .toList();
+  }
+
+  @protected
+  List<(String, Uint64List)>
+      dco_decode_list_record_string_list_prim_usize_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_record_string_list_prim_usize_strict)
+        .toList();
+  }
+
+  @protected
+  List<(int, List<Condition>)> dco_decode_list_record_u_32_list_condition(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_record_u_32_list_condition)
+        .toList();
   }
 
   @protected
@@ -3781,6 +4126,15 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  Map<String, Uint64List>? dco_decode_opt_Map_String_list_prim_usize_strict(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_Map_String_list_prim_usize_strict(raw);
+  }
+
+  @protected
   String? dco_decode_opt_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_String(raw);
@@ -3796,6 +4150,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   BdkDescriptor? dco_decode_opt_box_autoadd_bdk_descriptor(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_bdk_descriptor(raw);
+  }
+
+  @protected
+  BdkPolicy? dco_decode_opt_box_autoadd_bdk_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_bdk_policy(raw);
   }
 
   @protected
@@ -3817,6 +4177,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  bool? dco_decode_opt_box_autoadd_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_bool(raw);
+  }
+
+  @protected
   double? dco_decode_opt_box_autoadd_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_f_32(raw);
@@ -3826,6 +4192,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   FeeRate? dco_decode_opt_box_autoadd_fee_rate(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_fee_rate(raw);
+  }
+
+  @protected
+  LockTime? dco_decode_opt_box_autoadd_lock_time(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_lock_time(raw);
   }
 
   @protected
@@ -3914,6 +4286,27 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  PkOrF dco_decode_pk_or_f(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return PkOrF_Pubkey(
+          value: dco_decode_String(raw[1]),
+        );
+      case 1:
+        return PkOrF_XOnlyPubkey(
+          value: dco_decode_String(raw[1]),
+        );
+      case 2:
+        return PkOrF_Fingerprint(
+          value: dco_decode_String(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   PsbtSigHashType dco_decode_psbt_sig_hash_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3967,6 +4360,20 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  (Uint32List, List<Condition>)
+      dco_decode_record_list_prim_u_32_strict_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_list_prim_u_32_strict(arr[0]),
+      dco_decode_list_condition(arr[1]),
+    );
+  }
+
+  @protected
   (OutPoint, Input, BigInt) dco_decode_record_out_point_input_usize(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3978,6 +4385,33 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       dco_decode_out_point(arr[0]),
       dco_decode_input(arr[1]),
       dco_decode_usize(arr[2]),
+    );
+  }
+
+  @protected
+  (String, Uint64List) dco_decode_record_string_list_prim_usize_strict(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_String(arr[0]),
+      dco_decode_list_prim_usize_strict(arr[1]),
+    );
+  }
+
+  @protected
+  (int, List<Condition>) dco_decode_record_u_32_list_condition(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_u_32(arr[0]),
+      dco_decode_list_condition(arr[1]),
     );
   }
 
@@ -4008,6 +4442,91 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       forceStartTime: dco_decode_bool(arr[2]),
       pollRateSec: dco_decode_u_64(arr[3]),
     );
+  }
+
+  @protected
+  Satisfaction dco_decode_satisfaction(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return Satisfaction_Partial(
+          n: dco_decode_u_64(raw[1]),
+          m: dco_decode_u_64(raw[2]),
+          items: dco_decode_list_prim_u_64_strict(raw[3]),
+          sorted: dco_decode_opt_box_autoadd_bool(raw[4]),
+          conditions: dco_decode_Map_u_32_list_condition(raw[5]),
+        );
+      case 1:
+        return Satisfaction_PartialComplete(
+          n: dco_decode_u_64(raw[1]),
+          m: dco_decode_u_64(raw[2]),
+          items: dco_decode_list_prim_u_64_strict(raw[3]),
+          sorted: dco_decode_opt_box_autoadd_bool(raw[4]),
+          conditions:
+              dco_decode_Map_list_prim_u_32_strict_list_condition(raw[5]),
+        );
+      case 2:
+        return Satisfaction_Complete(
+          condition: dco_decode_box_autoadd_condition(raw[1]),
+        );
+      case 3:
+        return Satisfaction_None(
+          msg: dco_decode_String(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
+  SatisfiableItem dco_decode_satisfiable_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return SatisfiableItem_EcdsaSignature(
+          key: dco_decode_box_autoadd_pk_or_f(raw[1]),
+        );
+      case 1:
+        return SatisfiableItem_SchnorrSignature(
+          key: dco_decode_box_autoadd_pk_or_f(raw[1]),
+        );
+      case 2:
+        return SatisfiableItem_Sha256Preimage(
+          hash: dco_decode_String(raw[1]),
+        );
+      case 3:
+        return SatisfiableItem_Hash256Preimage(
+          hash: dco_decode_String(raw[1]),
+        );
+      case 4:
+        return SatisfiableItem_Ripemd160Preimage(
+          hash: dco_decode_String(raw[1]),
+        );
+      case 5:
+        return SatisfiableItem_Hash160Preimage(
+          hash: dco_decode_String(raw[1]),
+        );
+      case 6:
+        return SatisfiableItem_AbsoluteTimelock(
+          value: dco_decode_box_autoadd_lock_time(raw[1]),
+        );
+      case 7:
+        return SatisfiableItem_RelativeTimelock(
+          value: dco_decode_u_32(raw[1]),
+        );
+      case 8:
+        return SatisfiableItem_Multisig(
+          keys: dco_decode_list_pk_or_f(raw[1]),
+          threshold: dco_decode_u_64(raw[2]),
+        );
+      case 9:
+        return SatisfiableItem_Thresh(
+          items: dco_decode_list_bdk_policy(raw[1]),
+          threshold: dco_decode_u_64(raw[2]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
   }
 
   @protected
@@ -4159,6 +4678,33 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  Map<String, Uint64List> sse_decode_Map_String_list_prim_usize_strict(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner =
+        sse_decode_list_record_string_list_prim_usize_strict(deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
+  Map<Uint32List, List<Condition>>
+      sse_decode_Map_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_record_list_prim_u_32_strict_list_condition(
+        deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
+  Map<int, List<Condition>> sse_decode_Map_u_32_list_condition(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_record_u_32_list_condition(deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
   Address sse_decode_RustOpaque_bdkbitcoinAddress(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -4187,6 +4733,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return ExtendedDescriptorImpl.frbInternalSseDecode(
+        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+  }
+
+  @protected
+  Policy sse_decode_RustOpaque_bdkdescriptorPolicy(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return PolicyImpl.frbInternalSseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -4566,6 +5120,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  BdkPolicy sse_decode_bdk_policy(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_ptr = sse_decode_RustOpaque_bdkdescriptorPolicy(deserializer);
+    return BdkPolicy(ptr: var_ptr);
+  }
+
+  @protected
   BdkPsbt sse_decode_bdk_psbt(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_ptr =
@@ -4694,6 +5255,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  BdkPolicy sse_decode_box_autoadd_bdk_policy(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_bdk_policy(deserializer));
+  }
+
+  @protected
   BdkPsbt sse_decode_box_autoadd_bdk_psbt(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_bdk_psbt(deserializer));
@@ -4730,6 +5297,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_blockchain_config(deserializer));
+  }
+
+  @protected
+  bool sse_decode_box_autoadd_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_bool(deserializer));
+  }
+
+  @protected
+  Condition sse_decode_box_autoadd_condition(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_condition(deserializer));
   }
 
   @protected
@@ -4801,6 +5380,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   OutPoint sse_decode_box_autoadd_out_point(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_out_point(deserializer));
+  }
+
+  @protected
+  PkOrF sse_decode_box_autoadd_pk_or_f(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_pk_or_f(deserializer));
   }
 
   @protected
@@ -4881,6 +5466,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return ChangeSpendPolicy.values[inner];
+  }
+
+  @protected
+  Condition sse_decode_condition(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_csv = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_timelock = sse_decode_opt_box_autoadd_lock_time(deserializer);
+    return Condition(csv: var_csv, timelock: var_timelock);
   }
 
   @protected
@@ -5068,6 +5661,30 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  List<BdkPolicy> sse_decode_list_bdk_policy(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <BdkPolicy>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_bdk_policy(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<Condition> sse_decode_list_condition(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <Condition>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_condition(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<Uint8List> sse_decode_list_list_prim_u_8_strict(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5105,6 +5722,32 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  List<PkOrF> sse_decode_list_pk_or_f(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <PkOrF>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_pk_or_f(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  Uint32List sse_decode_list_prim_u_32_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint32List(len_);
+  }
+
+  @protected
+  Uint64List sse_decode_list_prim_u_64_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint64List(len_);
+  }
+
+  @protected
   List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
@@ -5116,6 +5759,55 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
     return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  Uint64List sse_decode_list_prim_usize_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint64List(len_);
+  }
+
+  @protected
+  List<(Uint32List, List<Condition>)>
+      sse_decode_list_record_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(Uint32List, List<Condition>)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(
+          sse_decode_record_list_prim_u_32_strict_list_condition(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<(String, Uint64List)>
+      sse_decode_list_record_string_list_prim_usize_strict(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(String, Uint64List)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_string_list_prim_usize_strict(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<(int, List<Condition>)> sse_decode_list_record_u_32_list_condition(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(int, List<Condition>)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_u_32_list_condition(deserializer));
+    }
+    return ans_;
   }
 
   @protected
@@ -5207,6 +5899,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  Map<String, Uint64List>? sse_decode_opt_Map_String_list_prim_usize_strict(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_Map_String_list_prim_usize_strict(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   String? sse_decode_opt_String(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -5236,6 +5940,18 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_bdk_descriptor(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  BdkPolicy? sse_decode_opt_box_autoadd_bdk_policy(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_bdk_policy(deserializer));
     } else {
       return null;
     }
@@ -5278,6 +5994,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_bool(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   double? sse_decode_opt_box_autoadd_f_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -5294,6 +6021,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_fee_rate(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  LockTime? sse_decode_opt_box_autoadd_lock_time(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_lock_time(deserializer));
     } else {
       return null;
     }
@@ -5424,6 +6162,26 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  PkOrF sse_decode_pk_or_f(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_value = sse_decode_String(deserializer);
+        return PkOrF_Pubkey(value: var_value);
+      case 1:
+        var var_value = sse_decode_String(deserializer);
+        return PkOrF_XOnlyPubkey(value: var_value);
+      case 2:
+        var var_value = sse_decode_String(deserializer);
+        return PkOrF_Fingerprint(value: var_value);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   PsbtSigHashType sse_decode_psbt_sig_hash_type(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_inner = sse_decode_u_32(deserializer);
@@ -5465,6 +6223,16 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  (Uint32List, List<Condition>)
+      sse_decode_record_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_list_prim_u_32_strict(deserializer);
+    var var_field1 = sse_decode_list_condition(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
   (OutPoint, Input, BigInt) sse_decode_record_out_point_input_usize(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5472,6 +6240,24 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     var var_field1 = sse_decode_input(deserializer);
     var var_field2 = sse_decode_usize(deserializer);
     return (var_field0, var_field1, var_field2);
+  }
+
+  @protected
+  (String, Uint64List) sse_decode_record_string_list_prim_usize_strict(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_list_prim_usize_strict(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (int, List<Condition>) sse_decode_record_u_32_list_condition(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_u_32(deserializer);
+    var var_field1 = sse_decode_list_condition(deserializer);
+    return (var_field0, var_field1);
   }
 
   @protected
@@ -5503,6 +6289,93 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
         startTime: var_startTime,
         forceStartTime: var_forceStartTime,
         pollRateSec: var_pollRateSec);
+  }
+
+  @protected
+  Satisfaction sse_decode_satisfaction(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_n = sse_decode_u_64(deserializer);
+        var var_m = sse_decode_u_64(deserializer);
+        var var_items = sse_decode_list_prim_u_64_strict(deserializer);
+        var var_sorted = sse_decode_opt_box_autoadd_bool(deserializer);
+        var var_conditions = sse_decode_Map_u_32_list_condition(deserializer);
+        return Satisfaction_Partial(
+            n: var_n,
+            m: var_m,
+            items: var_items,
+            sorted: var_sorted,
+            conditions: var_conditions);
+      case 1:
+        var var_n = sse_decode_u_64(deserializer);
+        var var_m = sse_decode_u_64(deserializer);
+        var var_items = sse_decode_list_prim_u_64_strict(deserializer);
+        var var_sorted = sse_decode_opt_box_autoadd_bool(deserializer);
+        var var_conditions =
+            sse_decode_Map_list_prim_u_32_strict_list_condition(deserializer);
+        return Satisfaction_PartialComplete(
+            n: var_n,
+            m: var_m,
+            items: var_items,
+            sorted: var_sorted,
+            conditions: var_conditions);
+      case 2:
+        var var_condition = sse_decode_box_autoadd_condition(deserializer);
+        return Satisfaction_Complete(condition: var_condition);
+      case 3:
+        var var_msg = sse_decode_String(deserializer);
+        return Satisfaction_None(msg: var_msg);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
+  SatisfiableItem sse_decode_satisfiable_item(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_key = sse_decode_box_autoadd_pk_or_f(deserializer);
+        return SatisfiableItem_EcdsaSignature(key: var_key);
+      case 1:
+        var var_key = sse_decode_box_autoadd_pk_or_f(deserializer);
+        return SatisfiableItem_SchnorrSignature(key: var_key);
+      case 2:
+        var var_hash = sse_decode_String(deserializer);
+        return SatisfiableItem_Sha256Preimage(hash: var_hash);
+      case 3:
+        var var_hash = sse_decode_String(deserializer);
+        return SatisfiableItem_Hash256Preimage(hash: var_hash);
+      case 4:
+        var var_hash = sse_decode_String(deserializer);
+        return SatisfiableItem_Ripemd160Preimage(hash: var_hash);
+      case 5:
+        var var_hash = sse_decode_String(deserializer);
+        return SatisfiableItem_Hash160Preimage(hash: var_hash);
+      case 6:
+        var var_value = sse_decode_box_autoadd_lock_time(deserializer);
+        return SatisfiableItem_AbsoluteTimelock(value: var_value);
+      case 7:
+        var var_value = sse_decode_u_32(deserializer);
+        return SatisfiableItem_RelativeTimelock(value: var_value);
+      case 8:
+        var var_keys = sse_decode_list_pk_or_f(deserializer);
+        var var_threshold = sse_decode_u_64(deserializer);
+        return SatisfiableItem_Multisig(
+            keys: var_keys, threshold: var_threshold);
+      case 9:
+        var var_items = sse_decode_list_bdk_policy(deserializer);
+        var var_threshold = sse_decode_u_64(deserializer);
+        return SatisfiableItem_Thresh(
+            items: var_items, threshold: var_threshold);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -5680,6 +6553,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  int cst_encode_RustOpaque_bdkdescriptorPolicy(Policy raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+// ignore: invalid_use_of_internal_member
+    return (raw as PolicyImpl).frbInternalCstEncode();
+  }
+
+  @protected
   int cst_encode_RustOpaque_bdkkeysDescriptorPublicKey(
       DescriptorPublicKey raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -5798,6 +6678,30 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_Map_String_list_prim_usize_strict(
+      Map<String, Uint64List> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_string_list_prim_usize_strict(
+        self.entries.map((e) => (e.key, e.value)).toList(), serializer);
+  }
+
+  @protected
+  void sse_encode_Map_list_prim_u_32_strict_list_condition(
+      Map<Uint32List, List<Condition>> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_list_prim_u_32_strict_list_condition(
+        self.entries.map((e) => (e.key, e.value)).toList(), serializer);
+  }
+
+  @protected
+  void sse_encode_Map_u_32_list_condition(
+      Map<int, List<Condition>> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_u_32_list_condition(
+        self.entries.map((e) => (e.key, e.value)).toList(), serializer);
+  }
+
+  @protected
   void sse_encode_RustOpaque_bdkbitcoinAddress(
       Address self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5830,6 +6734,14 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     sse_encode_usize(
         (self as ExtendedDescriptorImpl).frbInternalSseEncode(move: null),
         serializer);
+  }
+
+  @protected
+  void sse_encode_RustOpaque_bdkdescriptorPolicy(
+      Policy self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+        (self as PolicyImpl).frbInternalSseEncode(move: null), serializer);
   }
 
   @protected
@@ -6195,6 +7107,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_bdk_policy(BdkPolicy self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_RustOpaque_bdkdescriptorPolicy(self.ptr, serializer);
+  }
+
+  @protected
   void sse_encode_bdk_psbt(BdkPsbt self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_RustOpaque_stdsyncMutexbdkbitcoinpsbtPartiallySignedTransaction(
@@ -6317,6 +7235,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_bdk_policy(
+      BdkPolicy self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bdk_policy(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_bdk_psbt(BdkPsbt self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_bdk_psbt(self, serializer);
@@ -6355,6 +7280,19 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       BlockchainConfig self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_blockchain_config(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_bool(bool self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_condition(
+      Condition self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_condition(self, serializer);
   }
 
   @protected
@@ -6430,6 +7368,12 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       OutPoint self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_out_point(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_pk_or_f(PkOrF self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_pk_or_f(self, serializer);
   }
 
   @protected
@@ -6511,6 +7455,13 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
       ChangeSpendPolicy self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_condition(Condition self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_u_32(self.csv, serializer);
+    sse_encode_opt_box_autoadd_lock_time(self.timelock, serializer);
   }
 
   @protected
@@ -6680,6 +7631,26 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_list_bdk_policy(
+      List<BdkPolicy> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_bdk_policy(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_condition(
+      List<Condition> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_condition(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_list_prim_u_8_strict(
       List<Uint8List> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -6710,6 +7681,31 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_list_pk_or_f(List<PkOrF> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_pk_or_f(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_prim_u_32_strict(
+      Uint32List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint32List(self);
+  }
+
+  @protected
+  void sse_encode_list_prim_u_64_strict(
+      Uint64List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint64List(self);
+  }
+
+  @protected
   void sse_encode_list_prim_u_8_loose(
       List<int> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -6724,6 +7720,44 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     serializer.buffer.putUint8List(self);
+  }
+
+  @protected
+  void sse_encode_list_prim_usize_strict(
+      Uint64List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint64List(self);
+  }
+
+  @protected
+  void sse_encode_list_record_list_prim_u_32_strict_list_condition(
+      List<(Uint32List, List<Condition>)> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_list_prim_u_32_strict_list_condition(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_record_string_list_prim_usize_strict(
+      List<(String, Uint64List)> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_string_list_prim_usize_strict(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_record_u_32_list_condition(
+      List<(int, List<Condition>)> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_u_32_list_condition(item, serializer);
+    }
   }
 
   @protected
@@ -6795,6 +7829,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_opt_Map_String_list_prim_usize_strict(
+      Map<String, Uint64List>? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_Map_String_list_prim_usize_strict(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -6823,6 +7868,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_bdk_descriptor(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_bdk_policy(
+      BdkPolicy? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_bdk_policy(self, serializer);
     }
   }
 
@@ -6860,6 +7916,16 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_bool(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_f_32(double? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -6877,6 +7943,17 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_fee_rate(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_lock_time(
+      LockTime? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_lock_time(self, serializer);
     }
   }
 
@@ -6995,6 +8072,24 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_pk_or_f(PkOrF self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case PkOrF_Pubkey(value: final value):
+        sse_encode_i_32(0, serializer);
+        sse_encode_String(value, serializer);
+      case PkOrF_XOnlyPubkey(value: final value):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(value, serializer);
+      case PkOrF_Fingerprint(value: final value):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(value, serializer);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   void sse_encode_psbt_sig_hash_type(
       PsbtSigHashType self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -7032,12 +8127,36 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
   }
 
   @protected
+  void sse_encode_record_list_prim_u_32_strict_list_condition(
+      (Uint32List, List<Condition>) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_prim_u_32_strict(self.$1, serializer);
+    sse_encode_list_condition(self.$2, serializer);
+  }
+
+  @protected
   void sse_encode_record_out_point_input_usize(
       (OutPoint, Input, BigInt) self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_out_point(self.$1, serializer);
     sse_encode_input(self.$2, serializer);
     sse_encode_usize(self.$3, serializer);
+  }
+
+  @protected
+  void sse_encode_record_string_list_prim_usize_strict(
+      (String, Uint64List) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_list_prim_usize_strict(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_record_u_32_list_condition(
+      (int, List<Condition>) self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.$1, serializer);
+    sse_encode_list_condition(self.$2, serializer);
   }
 
   @protected
@@ -7058,6 +8177,96 @@ class coreApiImpl extends coreApiImplPlatform implements coreApi {
     sse_encode_u_64(self.startTime, serializer);
     sse_encode_bool(self.forceStartTime, serializer);
     sse_encode_u_64(self.pollRateSec, serializer);
+  }
+
+  @protected
+  void sse_encode_satisfaction(Satisfaction self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case Satisfaction_Partial(
+          n: final n,
+          m: final m,
+          items: final items,
+          sorted: final sorted,
+          conditions: final conditions
+        ):
+        sse_encode_i_32(0, serializer);
+        sse_encode_u_64(n, serializer);
+        sse_encode_u_64(m, serializer);
+        sse_encode_list_prim_u_64_strict(items, serializer);
+        sse_encode_opt_box_autoadd_bool(sorted, serializer);
+        sse_encode_Map_u_32_list_condition(conditions, serializer);
+      case Satisfaction_PartialComplete(
+          n: final n,
+          m: final m,
+          items: final items,
+          sorted: final sorted,
+          conditions: final conditions
+        ):
+        sse_encode_i_32(1, serializer);
+        sse_encode_u_64(n, serializer);
+        sse_encode_u_64(m, serializer);
+        sse_encode_list_prim_u_64_strict(items, serializer);
+        sse_encode_opt_box_autoadd_bool(sorted, serializer);
+        sse_encode_Map_list_prim_u_32_strict_list_condition(
+            conditions, serializer);
+      case Satisfaction_Complete(condition: final condition):
+        sse_encode_i_32(2, serializer);
+        sse_encode_box_autoadd_condition(condition, serializer);
+      case Satisfaction_None(msg: final msg):
+        sse_encode_i_32(3, serializer);
+        sse_encode_String(msg, serializer);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
+  void sse_encode_satisfiable_item(
+      SatisfiableItem self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case SatisfiableItem_EcdsaSignature(key: final key):
+        sse_encode_i_32(0, serializer);
+        sse_encode_box_autoadd_pk_or_f(key, serializer);
+      case SatisfiableItem_SchnorrSignature(key: final key):
+        sse_encode_i_32(1, serializer);
+        sse_encode_box_autoadd_pk_or_f(key, serializer);
+      case SatisfiableItem_Sha256Preimage(hash: final hash):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(hash, serializer);
+      case SatisfiableItem_Hash256Preimage(hash: final hash):
+        sse_encode_i_32(3, serializer);
+        sse_encode_String(hash, serializer);
+      case SatisfiableItem_Ripemd160Preimage(hash: final hash):
+        sse_encode_i_32(4, serializer);
+        sse_encode_String(hash, serializer);
+      case SatisfiableItem_Hash160Preimage(hash: final hash):
+        sse_encode_i_32(5, serializer);
+        sse_encode_String(hash, serializer);
+      case SatisfiableItem_AbsoluteTimelock(value: final value):
+        sse_encode_i_32(6, serializer);
+        sse_encode_box_autoadd_lock_time(value, serializer);
+      case SatisfiableItem_RelativeTimelock(value: final value):
+        sse_encode_i_32(7, serializer);
+        sse_encode_u_32(value, serializer);
+      case SatisfiableItem_Multisig(
+          keys: final keys,
+          threshold: final threshold
+        ):
+        sse_encode_i_32(8, serializer);
+        sse_encode_list_pk_or_f(keys, serializer);
+        sse_encode_u_64(threshold, serializer);
+      case SatisfiableItem_Thresh(
+          items: final items,
+          threshold: final threshold
+        ):
+        sse_encode_i_32(9, serializer);
+        sse_encode_list_bdk_policy(items, serializer);
+        sse_encode_u_64(threshold, serializer);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -7383,5 +8592,25 @@ class MutexWalletAnyDatabaseImpl extends RustOpaque
         .instance.api.rust_arc_decrement_strong_count_MutexWalletAnyDatabase,
     rustArcDecrementStrongCountPtr: core
         .instance.api.rust_arc_decrement_strong_count_MutexWalletAnyDatabasePtr,
+  );
+}
+
+@sealed
+class PolicyImpl extends RustOpaque implements Policy {
+  // Not to be used by end users
+  PolicyImpl.frbInternalDcoDecode(List<dynamic> wire)
+      : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  PolicyImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
+      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount:
+        core.instance.api.rust_arc_increment_strong_count_Policy,
+    rustArcDecrementStrongCount:
+        core.instance.api.rust_arc_decrement_strong_count_Policy,
+    rustArcDecrementStrongCountPtr:
+        core.instance.api.rust_arc_decrement_strong_count_PolicyPtr,
   );
 }

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -66,7 +66,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexbdkbitcoinpsbtPartiallySignedTransactionPtr;
 
   @protected
-  Map<String, Uint64List> dco_decode_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List> dco_decode_Map_String_list_prim_u_32_strict(
       dynamic raw);
 
   @protected
@@ -377,15 +377,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
-  Uint64List dco_decode_list_prim_usize_strict(dynamic raw);
-
-  @protected
   List<(Uint32List, List<Condition>)>
       dco_decode_list_record_list_prim_u_32_strict_list_condition(dynamic raw);
 
   @protected
-  List<(String, Uint64List)>
-      dco_decode_list_record_string_list_prim_usize_strict(dynamic raw);
+  List<(String, Uint32List)>
+      dco_decode_list_record_string_list_prim_u_32_strict(dynamic raw);
 
   @protected
   List<(int, List<Condition>)> dco_decode_list_record_u_32_list_condition(
@@ -413,7 +410,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Network dco_decode_network(dynamic raw);
 
   @protected
-  Map<String, Uint64List>? dco_decode_opt_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List>? dco_decode_opt_Map_String_list_prim_u_32_strict(
       dynamic raw);
 
   @protected
@@ -505,7 +502,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       dynamic raw);
 
   @protected
-  (String, Uint64List) dco_decode_record_string_list_prim_usize_strict(
+  (String, Uint32List) dco_decode_record_string_list_prim_u_32_strict(
       dynamic raw);
 
   @protected
@@ -572,7 +569,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   WordCount dco_decode_word_count(dynamic raw);
 
   @protected
-  Map<String, Uint64List> sse_decode_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List> sse_decode_Map_String_list_prim_u_32_strict(
       SseDeserializer deserializer);
 
   @protected
@@ -909,16 +906,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
-  Uint64List sse_decode_list_prim_usize_strict(SseDeserializer deserializer);
-
-  @protected
   List<(Uint32List, List<Condition>)>
       sse_decode_list_record_list_prim_u_32_strict_list_condition(
           SseDeserializer deserializer);
 
   @protected
-  List<(String, Uint64List)>
-      sse_decode_list_record_string_list_prim_usize_strict(
+  List<(String, Uint32List)>
+      sse_decode_list_record_string_list_prim_u_32_strict(
           SseDeserializer deserializer);
 
   @protected
@@ -949,7 +943,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Network sse_decode_network(SseDeserializer deserializer);
 
   @protected
-  Map<String, Uint64List>? sse_decode_opt_Map_String_list_prim_usize_strict(
+  Map<String, Uint32List>? sse_decode_opt_Map_String_list_prim_u_32_strict(
       SseDeserializer deserializer);
 
   @protected
@@ -1053,7 +1047,7 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
-  (String, Uint64List) sse_decode_record_string_list_prim_usize_strict(
+  (String, Uint32List) sse_decode_record_string_list_prim_u_32_strict(
       SseDeserializer deserializer);
 
   @protected
@@ -1124,11 +1118,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   WordCount sse_decode_word_count(SseDeserializer deserializer);
 
   @protected
-  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
-      cst_encode_Map_String_list_prim_usize_strict(
-          Map<String, Uint64List> raw) {
+  ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
+      cst_encode_Map_String_list_prim_u_32_strict(Map<String, Uint32List> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    return cst_encode_list_record_string_list_prim_usize_strict(
+    return cst_encode_list_record_string_list_prim_u_32_strict(
         raw.entries.map((e) => (e.key, e.value)).toList());
   }
 
@@ -1612,13 +1605,6 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_cst_list_prim_usize_strict>
-      cst_encode_list_prim_usize_strict(Uint64List raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    throw UnimplementedError('Not implemented in this codec');
-  }
-
-  @protected
   ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
       cst_encode_list_record_list_prim_u_32_strict_list_condition(
           List<(Uint32List, List<Condition>)> raw) {
@@ -1633,14 +1619,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
-      cst_encode_list_record_string_list_prim_usize_strict(
-          List<(String, Uint64List)> raw) {
+  ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
+      cst_encode_list_record_string_list_prim_u_32_strict(
+          List<(String, Uint32List)> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ans =
-        wire.cst_new_list_record_string_list_prim_usize_strict(raw.length);
+        wire.cst_new_list_record_string_list_prim_u_32_strict(raw.length);
     for (var i = 0; i < raw.length; ++i) {
-      cst_api_fill_to_wire_record_string_list_prim_usize_strict(
+      cst_api_fill_to_wire_record_string_list_prim_u_32_strict(
           raw[i], ans.ref.ptr[i]);
     }
     return ans;
@@ -1701,13 +1687,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
-      cst_encode_opt_Map_String_list_prim_usize_strict(
-          Map<String, Uint64List>? raw) {
+  ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
+      cst_encode_opt_Map_String_list_prim_u_32_strict(
+          Map<String, Uint32List>? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null
         ? ffi.nullptr
-        : cst_encode_Map_String_list_prim_usize_strict(raw);
+        : cst_encode_Map_String_list_prim_u_32_strict(raw);
   }
 
   @protected
@@ -2953,11 +2939,11 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_record_string_list_prim_usize_strict(
-      (String, Uint64List) apiObj,
-      wire_cst_record_string_list_prim_usize_strict wireObj) {
+  void cst_api_fill_to_wire_record_string_list_prim_u_32_strict(
+      (String, Uint32List) apiObj,
+      wire_cst_record_string_list_prim_u_32_strict wireObj) {
     wireObj.field0 = cst_encode_String(apiObj.$1);
-    wireObj.field1 = cst_encode_list_prim_usize_strict(apiObj.$2);
+    wireObj.field1 = cst_encode_list_prim_u_32_strict(apiObj.$2);
   }
 
   @protected
@@ -3240,8 +3226,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   int cst_encode_word_count(WordCount raw);
 
   @protected
-  void sse_encode_Map_String_list_prim_usize_strict(
-      Map<String, Uint64List> self, SseSerializer serializer);
+  void sse_encode_Map_String_list_prim_u_32_strict(
+      Map<String, Uint32List> self, SseSerializer serializer);
 
   @protected
   void sse_encode_Map_list_prim_u_32_strict_list_condition(
@@ -3602,16 +3588,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       Uint8List self, SseSerializer serializer);
 
   @protected
-  void sse_encode_list_prim_usize_strict(
-      Uint64List self, SseSerializer serializer);
-
-  @protected
   void sse_encode_list_record_list_prim_u_32_strict_list_condition(
       List<(Uint32List, List<Condition>)> self, SseSerializer serializer);
 
   @protected
-  void sse_encode_list_record_string_list_prim_usize_strict(
-      List<(String, Uint64List)> self, SseSerializer serializer);
+  void sse_encode_list_record_string_list_prim_u_32_strict(
+      List<(String, Uint32List)> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_record_u_32_list_condition(
@@ -3641,8 +3623,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_network(Network self, SseSerializer serializer);
 
   @protected
-  void sse_encode_opt_Map_String_list_prim_usize_strict(
-      Map<String, Uint64List>? self, SseSerializer serializer);
+  void sse_encode_opt_Map_String_list_prim_u_32_strict(
+      Map<String, Uint32List>? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer);
@@ -3747,8 +3729,8 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       (OutPoint, Input, BigInt) self, SseSerializer serializer);
 
   @protected
-  void sse_encode_record_string_list_prim_usize_strict(
-      (String, Uint64List) self, SseSerializer serializer);
+  void sse_encode_record_string_list_prim_u_32_strict(
+      (String, Uint32List) self, SseSerializer serializer);
 
   @protected
   void sse_encode_record_u_32_list_condition(
@@ -5752,9 +5734,9 @@ class coreWire implements BaseWire {
     bool drain_wallet,
     ffi.Pointer<wire_cst_bdk_script_buf> drain_to,
     ffi.Pointer<wire_cst_rbf_value> rbf,
-    ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+    ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
         internal_policy_path,
-    ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+    ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
         external_policy_path,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
   ) {
@@ -5796,9 +5778,9 @@ class coreWire implements BaseWire {
                       ffi.Pointer<wire_cst_bdk_script_buf>,
                       ffi.Pointer<wire_cst_rbf_value>,
                       ffi.Pointer<
-                          wire_cst_list_record_string_list_prim_usize_strict>,
+                          wire_cst_list_record_string_list_prim_u_32_strict>,
                       ffi.Pointer<
-                          wire_cst_list_record_string_list_prim_usize_strict>,
+                          wire_cst_list_record_string_list_prim_u_32_strict>,
                       ffi.Pointer<wire_cst_list_prim_u_8_loose>)>>(
           'frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish');
   late final _wire__crate__api__wallet__tx_builder_finish =
@@ -5817,8 +5799,8 @@ class coreWire implements BaseWire {
               bool,
               ffi.Pointer<wire_cst_bdk_script_buf>,
               ffi.Pointer<wire_cst_rbf_value>,
-              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>,
-              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>,
+              ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>,
+              ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>)>();
 
   void rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(
@@ -6786,22 +6768,6 @@ class coreWire implements BaseWire {
   late final _cst_new_list_prim_u_8_strict = _cst_new_list_prim_u_8_strictPtr
       .asFunction<ffi.Pointer<wire_cst_list_prim_u_8_strict> Function(int)>();
 
-  ffi.Pointer<wire_cst_list_prim_usize_strict> cst_new_list_prim_usize_strict(
-    int len,
-  ) {
-    return _cst_new_list_prim_usize_strict(
-      len,
-    );
-  }
-
-  late final _cst_new_list_prim_usize_strictPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_cst_list_prim_usize_strict> Function(
-              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_prim_usize_strict');
-  late final _cst_new_list_prim_usize_strict =
-      _cst_new_list_prim_usize_strictPtr.asFunction<
-          ffi.Pointer<wire_cst_list_prim_usize_strict> Function(int)>();
-
   ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
       cst_new_list_record_list_prim_u_32_strict_list_condition(
     int len,
@@ -6822,23 +6788,23 @@ class coreWire implements BaseWire {
           ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
               Function(int)>();
 
-  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
-      cst_new_list_record_string_list_prim_usize_strict(
+  ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
+      cst_new_list_record_string_list_prim_u_32_strict(
     int len,
   ) {
-    return _cst_new_list_record_string_list_prim_usize_strict(
+    return _cst_new_list_record_string_list_prim_u_32_strict(
       len,
     );
   }
 
-  late final _cst_new_list_record_string_list_prim_usize_strictPtr = _lookup<
+  late final _cst_new_list_record_string_list_prim_u_32_strictPtr = _lookup<
           ffi.NativeFunction<
-              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+              ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
                   Function(ffi.Int32)>>(
-      'frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict');
-  late final _cst_new_list_record_string_list_prim_usize_strict =
-      _cst_new_list_record_string_list_prim_usize_strictPtr.asFunction<
-          ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+      'frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict');
+  late final _cst_new_list_record_string_list_prim_u_32_strict =
+      _cst_new_list_record_string_list_prim_u_32_strictPtr.asFunction<
+          ffi.Pointer<wire_cst_list_record_string_list_prim_u_32_strict>
               Function(int)>();
 
   ffi.Pointer<wire_cst_list_record_u_32_list_condition>
@@ -7337,22 +7303,22 @@ final class wire_cst_rbf_value extends ffi.Struct {
   external RbfValueKind kind;
 }
 
-final class wire_cst_list_prim_usize_strict extends ffi.Struct {
-  external ffi.Pointer<ffi.UintPtr> ptr;
+final class wire_cst_list_prim_u_32_strict extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint32> ptr;
 
   @ffi.Int32()
   external int len;
 }
 
-final class wire_cst_record_string_list_prim_usize_strict extends ffi.Struct {
+final class wire_cst_record_string_list_prim_u_32_strict extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 
-  external ffi.Pointer<wire_cst_list_prim_usize_strict> field1;
+  external ffi.Pointer<wire_cst_list_prim_u_32_strict> field1;
 }
 
-final class wire_cst_list_record_string_list_prim_usize_strict
+final class wire_cst_list_record_string_list_prim_u_32_strict
     extends ffi.Struct {
-  external ffi.Pointer<wire_cst_record_string_list_prim_usize_strict> ptr;
+  external ffi.Pointer<wire_cst_record_string_list_prim_u_32_strict> ptr;
 
   @ffi.Int32()
   external int len;
@@ -7649,13 +7615,6 @@ final class wire_cst_list_local_utxo extends ffi.Struct {
 
 final class wire_cst_list_pk_or_f extends ffi.Struct {
   external ffi.Pointer<wire_cst_pk_or_f> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-final class wire_cst_list_prim_u_32_strict extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint32> ptr;
 
   @ffi.Int32()
   external int len;

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -40,6 +40,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       get rust_arc_decrement_strong_count_ExtendedDescriptorPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptorPtr;
 
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_PolicyPtr =>
+      wire._rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicyPtr;
+
   CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_DescriptorPublicKeyPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_bdkkeysDescriptorPublicKeyPtr;
@@ -63,6 +66,17 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncMutexbdkbitcoinpsbtPartiallySignedTransactionPtr;
 
   @protected
+  Map<String, Uint64List> dco_decode_Map_String_list_prim_usize_strict(
+      dynamic raw);
+
+  @protected
+  Map<Uint32List, List<Condition>>
+      dco_decode_Map_list_prim_u_32_strict_list_condition(dynamic raw);
+
+  @protected
+  Map<int, List<Condition>> dco_decode_Map_u_32_list_condition(dynamic raw);
+
+  @protected
   Address dco_decode_RustOpaque_bdkbitcoinAddress(dynamic raw);
 
   @protected
@@ -75,6 +89,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   ExtendedDescriptor dco_decode_RustOpaque_bdkdescriptorExtendedDescriptor(
       dynamic raw);
+
+  @protected
+  Policy dco_decode_RustOpaque_bdkdescriptorPolicy(dynamic raw);
 
   @protected
   DescriptorPublicKey dco_decode_RustOpaque_bdkkeysDescriptorPublicKey(
@@ -140,6 +157,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   BdkMnemonic dco_decode_bdk_mnemonic(dynamic raw);
 
   @protected
+  BdkPolicy dco_decode_bdk_policy(dynamic raw);
+
+  @protected
   BdkPsbt dco_decode_bdk_psbt(dynamic raw);
 
   @protected
@@ -190,6 +210,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   BdkMnemonic dco_decode_box_autoadd_bdk_mnemonic(dynamic raw);
 
   @protected
+  BdkPolicy dco_decode_box_autoadd_bdk_policy(dynamic raw);
+
+  @protected
   BdkPsbt dco_decode_box_autoadd_bdk_psbt(dynamic raw);
 
   @protected
@@ -206,6 +229,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   BlockchainConfig dco_decode_box_autoadd_blockchain_config(dynamic raw);
+
+  @protected
+  bool dco_decode_box_autoadd_bool(dynamic raw);
+
+  @protected
+  Condition dco_decode_box_autoadd_condition(dynamic raw);
 
   @protected
   ConsensusError dco_decode_box_autoadd_consensus_error(dynamic raw);
@@ -239,6 +268,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   OutPoint dco_decode_box_autoadd_out_point(dynamic raw);
+
+  @protected
+  PkOrF dco_decode_box_autoadd_pk_or_f(dynamic raw);
 
   @protected
   PsbtSigHashType dco_decode_box_autoadd_psbt_sig_hash_type(dynamic raw);
@@ -279,6 +311,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   ChangeSpendPolicy dco_decode_change_spend_policy(dynamic raw);
 
   @protected
+  Condition dco_decode_condition(dynamic raw);
+
+  @protected
   ConsensusError dco_decode_consensus_error(dynamic raw);
 
   @protected
@@ -312,6 +347,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   KeychainKind dco_decode_keychain_kind(dynamic raw);
 
   @protected
+  List<BdkPolicy> dco_decode_list_bdk_policy(dynamic raw);
+
+  @protected
+  List<Condition> dco_decode_list_condition(dynamic raw);
+
+  @protected
   List<Uint8List> dco_decode_list_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -321,10 +362,34 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   List<OutPoint> dco_decode_list_out_point(dynamic raw);
 
   @protected
+  List<PkOrF> dco_decode_list_pk_or_f(dynamic raw);
+
+  @protected
+  Uint32List dco_decode_list_prim_u_32_strict(dynamic raw);
+
+  @protected
+  Uint64List dco_decode_list_prim_u_64_strict(dynamic raw);
+
+  @protected
   List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  Uint64List dco_decode_list_prim_usize_strict(dynamic raw);
+
+  @protected
+  List<(Uint32List, List<Condition>)>
+      dco_decode_list_record_list_prim_u_32_strict_list_condition(dynamic raw);
+
+  @protected
+  List<(String, Uint64List)>
+      dco_decode_list_record_string_list_prim_usize_strict(dynamic raw);
+
+  @protected
+  List<(int, List<Condition>)> dco_decode_list_record_u_32_list_condition(
+      dynamic raw);
 
   @protected
   List<ScriptAmount> dco_decode_list_script_amount(dynamic raw);
@@ -348,6 +413,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Network dco_decode_network(dynamic raw);
 
   @protected
+  Map<String, Uint64List>? dco_decode_opt_Map_String_list_prim_usize_strict(
+      dynamic raw);
+
+  @protected
   String? dco_decode_opt_String(dynamic raw);
 
   @protected
@@ -355,6 +424,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   BdkDescriptor? dco_decode_opt_box_autoadd_bdk_descriptor(dynamic raw);
+
+  @protected
+  BdkPolicy? dco_decode_opt_box_autoadd_bdk_policy(dynamic raw);
 
   @protected
   BdkScriptBuf? dco_decode_opt_box_autoadd_bdk_script_buf(dynamic raw);
@@ -366,10 +438,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   BlockTime? dco_decode_opt_box_autoadd_block_time(dynamic raw);
 
   @protected
+  bool? dco_decode_opt_box_autoadd_bool(dynamic raw);
+
+  @protected
   double? dco_decode_opt_box_autoadd_f_32(dynamic raw);
 
   @protected
   FeeRate? dco_decode_opt_box_autoadd_fee_rate(dynamic raw);
+
+  @protected
+  LockTime? dco_decode_opt_box_autoadd_lock_time(dynamic raw);
 
   @protected
   PsbtSigHashType? dco_decode_opt_box_autoadd_psbt_sig_hash_type(dynamic raw);
@@ -403,6 +481,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Payload dco_decode_payload(dynamic raw);
 
   @protected
+  PkOrF dco_decode_pk_or_f(dynamic raw);
+
+  @protected
   PsbtSigHashType dco_decode_psbt_sig_hash_type(dynamic raw);
 
   @protected
@@ -416,14 +497,31 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       dynamic raw);
 
   @protected
+  (Uint32List, List<Condition>)
+      dco_decode_record_list_prim_u_32_strict_list_condition(dynamic raw);
+
+  @protected
   (OutPoint, Input, BigInt) dco_decode_record_out_point_input_usize(
       dynamic raw);
+
+  @protected
+  (String, Uint64List) dco_decode_record_string_list_prim_usize_strict(
+      dynamic raw);
+
+  @protected
+  (int, List<Condition>) dco_decode_record_u_32_list_condition(dynamic raw);
 
   @protected
   RpcConfig dco_decode_rpc_config(dynamic raw);
 
   @protected
   RpcSyncParams dco_decode_rpc_sync_params(dynamic raw);
+
+  @protected
+  Satisfaction dco_decode_satisfaction(dynamic raw);
+
+  @protected
+  SatisfiableItem dco_decode_satisfiable_item(dynamic raw);
 
   @protected
   ScriptAmount dco_decode_script_amount(dynamic raw);
@@ -474,6 +572,19 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   WordCount dco_decode_word_count(dynamic raw);
 
   @protected
+  Map<String, Uint64List> sse_decode_Map_String_list_prim_usize_strict(
+      SseDeserializer deserializer);
+
+  @protected
+  Map<Uint32List, List<Condition>>
+      sse_decode_Map_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer);
+
+  @protected
+  Map<int, List<Condition>> sse_decode_Map_u_32_list_condition(
+      SseDeserializer deserializer);
+
+  @protected
   Address sse_decode_RustOpaque_bdkbitcoinAddress(SseDeserializer deserializer);
 
   @protected
@@ -486,6 +597,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   ExtendedDescriptor sse_decode_RustOpaque_bdkdescriptorExtendedDescriptor(
+      SseDeserializer deserializer);
+
+  @protected
+  Policy sse_decode_RustOpaque_bdkdescriptorPolicy(
       SseDeserializer deserializer);
 
   @protected
@@ -556,6 +671,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   BdkMnemonic sse_decode_bdk_mnemonic(SseDeserializer deserializer);
 
   @protected
+  BdkPolicy sse_decode_bdk_policy(SseDeserializer deserializer);
+
+  @protected
   BdkPsbt sse_decode_bdk_psbt(SseDeserializer deserializer);
 
   @protected
@@ -611,6 +729,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   BdkMnemonic sse_decode_box_autoadd_bdk_mnemonic(SseDeserializer deserializer);
 
   @protected
+  BdkPolicy sse_decode_box_autoadd_bdk_policy(SseDeserializer deserializer);
+
+  @protected
   BdkPsbt sse_decode_box_autoadd_bdk_psbt(SseDeserializer deserializer);
 
   @protected
@@ -630,6 +751,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   BlockchainConfig sse_decode_box_autoadd_blockchain_config(
       SseDeserializer deserializer);
+
+  @protected
+  bool sse_decode_box_autoadd_bool(SseDeserializer deserializer);
+
+  @protected
+  Condition sse_decode_box_autoadd_condition(SseDeserializer deserializer);
 
   @protected
   ConsensusError sse_decode_box_autoadd_consensus_error(
@@ -668,6 +795,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   OutPoint sse_decode_box_autoadd_out_point(SseDeserializer deserializer);
+
+  @protected
+  PkOrF sse_decode_box_autoadd_pk_or_f(SseDeserializer deserializer);
 
   @protected
   PsbtSigHashType sse_decode_box_autoadd_psbt_sig_hash_type(
@@ -712,6 +842,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
+  Condition sse_decode_condition(SseDeserializer deserializer);
+
+  @protected
   ConsensusError sse_decode_consensus_error(SseDeserializer deserializer);
 
   @protected
@@ -745,6 +878,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   KeychainKind sse_decode_keychain_kind(SseDeserializer deserializer);
 
   @protected
+  List<BdkPolicy> sse_decode_list_bdk_policy(SseDeserializer deserializer);
+
+  @protected
+  List<Condition> sse_decode_list_condition(SseDeserializer deserializer);
+
+  @protected
   List<Uint8List> sse_decode_list_list_prim_u_8_strict(
       SseDeserializer deserializer);
 
@@ -755,10 +894,36 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   List<OutPoint> sse_decode_list_out_point(SseDeserializer deserializer);
 
   @protected
+  List<PkOrF> sse_decode_list_pk_or_f(SseDeserializer deserializer);
+
+  @protected
+  Uint32List sse_decode_list_prim_u_32_strict(SseDeserializer deserializer);
+
+  @protected
+  Uint64List sse_decode_list_prim_u_64_strict(SseDeserializer deserializer);
+
+  @protected
   List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  Uint64List sse_decode_list_prim_usize_strict(SseDeserializer deserializer);
+
+  @protected
+  List<(Uint32List, List<Condition>)>
+      sse_decode_list_record_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer);
+
+  @protected
+  List<(String, Uint64List)>
+      sse_decode_list_record_string_list_prim_usize_strict(
+          SseDeserializer deserializer);
+
+  @protected
+  List<(int, List<Condition>)> sse_decode_list_record_u_32_list_condition(
+      SseDeserializer deserializer);
 
   @protected
   List<ScriptAmount> sse_decode_list_script_amount(
@@ -784,6 +949,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Network sse_decode_network(SseDeserializer deserializer);
 
   @protected
+  Map<String, Uint64List>? sse_decode_opt_Map_String_list_prim_usize_strict(
+      SseDeserializer deserializer);
+
+  @protected
   String? sse_decode_opt_String(SseDeserializer deserializer);
 
   @protected
@@ -792,6 +961,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   BdkDescriptor? sse_decode_opt_box_autoadd_bdk_descriptor(
+      SseDeserializer deserializer);
+
+  @protected
+  BdkPolicy? sse_decode_opt_box_autoadd_bdk_policy(
       SseDeserializer deserializer);
 
   @protected
@@ -807,10 +980,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
+  bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer);
+
+  @protected
   double? sse_decode_opt_box_autoadd_f_32(SseDeserializer deserializer);
 
   @protected
   FeeRate? sse_decode_opt_box_autoadd_fee_rate(SseDeserializer deserializer);
+
+  @protected
+  LockTime? sse_decode_opt_box_autoadd_lock_time(SseDeserializer deserializer);
 
   @protected
   PsbtSigHashType? sse_decode_opt_box_autoadd_psbt_sig_hash_type(
@@ -848,6 +1027,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   Payload sse_decode_payload(SseDeserializer deserializer);
 
   @protected
+  PkOrF sse_decode_pk_or_f(SseDeserializer deserializer);
+
+  @protected
   PsbtSigHashType sse_decode_psbt_sig_hash_type(SseDeserializer deserializer);
 
   @protected
@@ -862,7 +1044,20 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SseDeserializer deserializer);
 
   @protected
+  (Uint32List, List<Condition>)
+      sse_decode_record_list_prim_u_32_strict_list_condition(
+          SseDeserializer deserializer);
+
+  @protected
   (OutPoint, Input, BigInt) sse_decode_record_out_point_input_usize(
+      SseDeserializer deserializer);
+
+  @protected
+  (String, Uint64List) sse_decode_record_string_list_prim_usize_strict(
+      SseDeserializer deserializer);
+
+  @protected
+  (int, List<Condition>) sse_decode_record_u_32_list_condition(
       SseDeserializer deserializer);
 
   @protected
@@ -870,6 +1065,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   RpcSyncParams sse_decode_rpc_sync_params(SseDeserializer deserializer);
+
+  @protected
+  Satisfaction sse_decode_satisfaction(SseDeserializer deserializer);
+
+  @protected
+  SatisfiableItem sse_decode_satisfiable_item(SseDeserializer deserializer);
 
   @protected
   ScriptAmount sse_decode_script_amount(SseDeserializer deserializer);
@@ -921,6 +1122,32 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
 
   @protected
   WordCount sse_decode_word_count(SseDeserializer deserializer);
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+      cst_encode_Map_String_list_prim_usize_strict(
+          Map<String, Uint64List> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_record_string_list_prim_usize_strict(
+        raw.entries.map((e) => (e.key, e.value)).toList());
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
+      cst_encode_Map_list_prim_u_32_strict_list_condition(
+          Map<Uint32List, List<Condition>> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_record_list_prim_u_32_strict_list_condition(
+        raw.entries.map((e) => (e.key, e.value)).toList());
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_u_32_list_condition>
+      cst_encode_Map_u_32_list_condition(Map<int, List<Condition>> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_record_u_32_list_condition(
+        raw.entries.map((e) => (e.key, e.value)).toList());
+  }
 
   @protected
   ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_String(String raw) {
@@ -1012,6 +1239,15 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_bdk_policy> cst_encode_box_autoadd_bdk_policy(
+      BdkPolicy raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_bdk_policy();
+    cst_api_fill_to_wire_bdk_policy(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_bdk_psbt> cst_encode_box_autoadd_bdk_psbt(BdkPsbt raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_bdk_psbt();
@@ -1061,6 +1297,21 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_blockchain_config();
     cst_api_fill_to_wire_blockchain_config(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<ffi.Bool> cst_encode_box_autoadd_bool(bool raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return wire.cst_new_box_autoadd_bool(cst_encode_bool(raw));
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_condition> cst_encode_box_autoadd_condition(
+      Condition raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_condition();
+    cst_api_fill_to_wire_condition(raw, ptr.ref);
     return ptr;
   }
 
@@ -1160,6 +1411,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_pk_or_f> cst_encode_box_autoadd_pk_or_f(PkOrF raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_pk_or_f();
+    cst_api_fill_to_wire_pk_or_f(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_psbt_sig_hash_type>
       cst_encode_box_autoadd_psbt_sig_hash_type(PsbtSigHashType raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1252,6 +1511,28 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_bdk_policy> cst_encode_list_bdk_policy(
+      List<BdkPolicy> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_bdk_policy(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_bdk_policy(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_condition> cst_encode_list_condition(
+      List<Condition> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_condition(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_condition(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_list_prim_u_8_strict>
       cst_encode_list_list_prim_u_8_strict(List<Uint8List> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1285,6 +1566,34 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_pk_or_f> cst_encode_list_pk_or_f(List<PkOrF> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_pk_or_f(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_pk_or_f(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_32_strict> cst_encode_list_prim_u_32_strict(
+      Uint32List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_prim_u_32_strict(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_64_strict> cst_encode_list_prim_u_64_strict(
+      Uint64List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_prim_u_64_strict(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw.inner);
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_prim_u_8_loose> cst_encode_list_prim_u_8_loose(
       List<int> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1299,6 +1608,53 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ans = wire.cst_new_list_prim_u_8_strict(raw.length);
     ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_usize_strict>
+      cst_encode_list_prim_usize_strict(Uint64List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    throw UnimplementedError('Not implemented in this codec');
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
+      cst_encode_list_record_list_prim_u_32_strict_list_condition(
+          List<(Uint32List, List<Condition>)> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire
+        .cst_new_list_record_list_prim_u_32_strict_list_condition(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_record_list_prim_u_32_strict_list_condition(
+          raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+      cst_encode_list_record_string_list_prim_usize_strict(
+          List<(String, Uint64List)> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans =
+        wire.cst_new_list_record_string_list_prim_usize_strict(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_record_string_list_prim_usize_strict(
+          raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_u_32_list_condition>
+      cst_encode_list_record_u_32_list_condition(
+          List<(int, List<Condition>)> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_record_u_32_list_condition(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_record_u_32_list_condition(raw[i], ans.ref.ptr[i]);
+    }
     return ans;
   }
 
@@ -1345,6 +1701,16 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+      cst_encode_opt_Map_String_list_prim_usize_strict(
+          Map<String, Uint64List>? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null
+        ? ffi.nullptr
+        : cst_encode_Map_String_list_prim_usize_strict(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_opt_String(
       String? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1365,6 +1731,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     return raw == null
         ? ffi.nullptr
         : cst_encode_box_autoadd_bdk_descriptor(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_bdk_policy> cst_encode_opt_box_autoadd_bdk_policy(
+      BdkPolicy? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_bdk_policy(raw);
   }
 
   @protected
@@ -1393,6 +1766,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  ffi.Pointer<ffi.Bool> cst_encode_opt_box_autoadd_bool(bool? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_bool(raw);
+  }
+
+  @protected
   ffi.Pointer<ffi.Float> cst_encode_opt_box_autoadd_f_32(double? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_box_autoadd_f_32(raw);
@@ -1403,6 +1782,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       FeeRate? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_box_autoadd_fee_rate(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_lock_time> cst_encode_opt_box_autoadd_lock_time(
+      LockTime? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_lock_time(raw);
   }
 
   @protected
@@ -1948,6 +2334,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_bdk_policy(
+      BdkPolicy apiObj, wire_cst_bdk_policy wireObj) {
+    wireObj.ptr = cst_encode_RustOpaque_bdkdescriptorPolicy(apiObj.ptr);
+  }
+
+  @protected
   void cst_api_fill_to_wire_bdk_psbt(
       BdkPsbt apiObj, wire_cst_bdk_psbt wireObj) {
     wireObj.ptr =
@@ -2063,6 +2455,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_bdk_policy(
+      BdkPolicy apiObj, ffi.Pointer<wire_cst_bdk_policy> wireObj) {
+    cst_api_fill_to_wire_bdk_policy(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_bdk_psbt(
       BdkPsbt apiObj, ffi.Pointer<wire_cst_bdk_psbt> wireObj) {
     cst_api_fill_to_wire_bdk_psbt(apiObj, wireObj.ref);
@@ -2097,6 +2495,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       BlockchainConfig apiObj,
       ffi.Pointer<wire_cst_blockchain_config> wireObj) {
     cst_api_fill_to_wire_blockchain_config(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_condition(
+      Condition apiObj, ffi.Pointer<wire_cst_condition> wireObj) {
+    cst_api_fill_to_wire_condition(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2160,6 +2564,12 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_pk_or_f(
+      PkOrF apiObj, ffi.Pointer<wire_cst_pk_or_f> wireObj) {
+    cst_api_fill_to_wire_pk_or_f(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_psbt_sig_hash_type(
       PsbtSigHashType apiObj,
       ffi.Pointer<wire_cst_psbt_sig_hash_type> wireObj) {
@@ -2209,6 +2619,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       SqliteDbConfiguration apiObj,
       ffi.Pointer<wire_cst_sqlite_db_configuration> wireObj) {
     cst_api_fill_to_wire_sqlite_db_configuration(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_condition(
+      Condition apiObj, wire_cst_condition wireObj) {
+    wireObj.csv = cst_encode_opt_box_autoadd_u_32(apiObj.csv);
+    wireObj.timelock = cst_encode_opt_box_autoadd_lock_time(apiObj.timelock);
   }
 
   @protected
@@ -2461,6 +2878,28 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_pk_or_f(PkOrF apiObj, wire_cst_pk_or_f wireObj) {
+    if (apiObj is PkOrF_Pubkey) {
+      var pre_value = cst_encode_String(apiObj.value);
+      wireObj.tag = 0;
+      wireObj.kind.Pubkey.value = pre_value;
+      return;
+    }
+    if (apiObj is PkOrF_XOnlyPubkey) {
+      var pre_value = cst_encode_String(apiObj.value);
+      wireObj.tag = 1;
+      wireObj.kind.XOnlyPubkey.value = pre_value;
+      return;
+    }
+    if (apiObj is PkOrF_Fingerprint) {
+      var pre_value = cst_encode_String(apiObj.value);
+      wireObj.tag = 2;
+      wireObj.kind.Fingerprint.value = pre_value;
+      return;
+    }
+  }
+
+  @protected
   void cst_api_fill_to_wire_psbt_sig_hash_type(
       PsbtSigHashType apiObj, wire_cst_psbt_sig_hash_type wireObj) {
     wireObj.inner = cst_encode_u_32(apiObj.inner);
@@ -2497,12 +2936,36 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_record_list_prim_u_32_strict_list_condition(
+      (Uint32List, List<Condition>) apiObj,
+      wire_cst_record_list_prim_u_32_strict_list_condition wireObj) {
+    wireObj.field0 = cst_encode_list_prim_u_32_strict(apiObj.$1);
+    wireObj.field1 = cst_encode_list_condition(apiObj.$2);
+  }
+
+  @protected
   void cst_api_fill_to_wire_record_out_point_input_usize(
       (OutPoint, Input, BigInt) apiObj,
       wire_cst_record_out_point_input_usize wireObj) {
     cst_api_fill_to_wire_out_point(apiObj.$1, wireObj.field0);
     cst_api_fill_to_wire_input(apiObj.$2, wireObj.field1);
     wireObj.field2 = cst_encode_usize(apiObj.$3);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_record_string_list_prim_usize_strict(
+      (String, Uint64List) apiObj,
+      wire_cst_record_string_list_prim_usize_strict wireObj) {
+    wireObj.field0 = cst_encode_String(apiObj.$1);
+    wireObj.field1 = cst_encode_list_prim_usize_strict(apiObj.$2);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_record_u_32_list_condition(
+      (int, List<Condition>) apiObj,
+      wire_cst_record_u_32_list_condition wireObj) {
+    wireObj.field0 = cst_encode_u_32(apiObj.$1);
+    wireObj.field1 = cst_encode_list_condition(apiObj.$2);
   }
 
   @protected
@@ -2523,6 +2986,122 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
     wireObj.start_time = cst_encode_u_64(apiObj.startTime);
     wireObj.force_start_time = cst_encode_bool(apiObj.forceStartTime);
     wireObj.poll_rate_sec = cst_encode_u_64(apiObj.pollRateSec);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_satisfaction(
+      Satisfaction apiObj, wire_cst_satisfaction wireObj) {
+    if (apiObj is Satisfaction_Partial) {
+      var pre_n = cst_encode_u_64(apiObj.n);
+      var pre_m = cst_encode_u_64(apiObj.m);
+      var pre_items = cst_encode_list_prim_u_64_strict(apiObj.items);
+      var pre_sorted = cst_encode_opt_box_autoadd_bool(apiObj.sorted);
+      var pre_conditions =
+          cst_encode_Map_u_32_list_condition(apiObj.conditions);
+      wireObj.tag = 0;
+      wireObj.kind.Partial.n = pre_n;
+      wireObj.kind.Partial.m = pre_m;
+      wireObj.kind.Partial.items = pre_items;
+      wireObj.kind.Partial.sorted = pre_sorted;
+      wireObj.kind.Partial.conditions = pre_conditions;
+      return;
+    }
+    if (apiObj is Satisfaction_PartialComplete) {
+      var pre_n = cst_encode_u_64(apiObj.n);
+      var pre_m = cst_encode_u_64(apiObj.m);
+      var pre_items = cst_encode_list_prim_u_64_strict(apiObj.items);
+      var pre_sorted = cst_encode_opt_box_autoadd_bool(apiObj.sorted);
+      var pre_conditions = cst_encode_Map_list_prim_u_32_strict_list_condition(
+          apiObj.conditions);
+      wireObj.tag = 1;
+      wireObj.kind.PartialComplete.n = pre_n;
+      wireObj.kind.PartialComplete.m = pre_m;
+      wireObj.kind.PartialComplete.items = pre_items;
+      wireObj.kind.PartialComplete.sorted = pre_sorted;
+      wireObj.kind.PartialComplete.conditions = pre_conditions;
+      return;
+    }
+    if (apiObj is Satisfaction_Complete) {
+      var pre_condition = cst_encode_box_autoadd_condition(apiObj.condition);
+      wireObj.tag = 2;
+      wireObj.kind.Complete.condition = pre_condition;
+      return;
+    }
+    if (apiObj is Satisfaction_None) {
+      var pre_msg = cst_encode_String(apiObj.msg);
+      wireObj.tag = 3;
+      wireObj.kind.None.msg = pre_msg;
+      return;
+    }
+  }
+
+  @protected
+  void cst_api_fill_to_wire_satisfiable_item(
+      SatisfiableItem apiObj, wire_cst_satisfiable_item wireObj) {
+    if (apiObj is SatisfiableItem_EcdsaSignature) {
+      var pre_key = cst_encode_box_autoadd_pk_or_f(apiObj.key);
+      wireObj.tag = 0;
+      wireObj.kind.EcdsaSignature.key = pre_key;
+      return;
+    }
+    if (apiObj is SatisfiableItem_SchnorrSignature) {
+      var pre_key = cst_encode_box_autoadd_pk_or_f(apiObj.key);
+      wireObj.tag = 1;
+      wireObj.kind.SchnorrSignature.key = pre_key;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Sha256Preimage) {
+      var pre_hash = cst_encode_String(apiObj.hash);
+      wireObj.tag = 2;
+      wireObj.kind.Sha256Preimage.hash = pre_hash;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Hash256Preimage) {
+      var pre_hash = cst_encode_String(apiObj.hash);
+      wireObj.tag = 3;
+      wireObj.kind.Hash256Preimage.hash = pre_hash;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Ripemd160Preimage) {
+      var pre_hash = cst_encode_String(apiObj.hash);
+      wireObj.tag = 4;
+      wireObj.kind.Ripemd160Preimage.hash = pre_hash;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Hash160Preimage) {
+      var pre_hash = cst_encode_String(apiObj.hash);
+      wireObj.tag = 5;
+      wireObj.kind.Hash160Preimage.hash = pre_hash;
+      return;
+    }
+    if (apiObj is SatisfiableItem_AbsoluteTimelock) {
+      var pre_value = cst_encode_box_autoadd_lock_time(apiObj.value);
+      wireObj.tag = 6;
+      wireObj.kind.AbsoluteTimelock.value = pre_value;
+      return;
+    }
+    if (apiObj is SatisfiableItem_RelativeTimelock) {
+      var pre_value = cst_encode_u_32(apiObj.value);
+      wireObj.tag = 7;
+      wireObj.kind.RelativeTimelock.value = pre_value;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Multisig) {
+      var pre_keys = cst_encode_list_pk_or_f(apiObj.keys);
+      var pre_threshold = cst_encode_u_64(apiObj.threshold);
+      wireObj.tag = 8;
+      wireObj.kind.Multisig.keys = pre_keys;
+      wireObj.kind.Multisig.threshold = pre_threshold;
+      return;
+    }
+    if (apiObj is SatisfiableItem_Thresh) {
+      var pre_items = cst_encode_list_bdk_policy(apiObj.items);
+      var pre_threshold = cst_encode_u_64(apiObj.threshold);
+      wireObj.tag = 9;
+      wireObj.kind.Thresh.items = pre_items;
+      wireObj.kind.Thresh.threshold = pre_threshold;
+      return;
+    }
   }
 
   @protected
@@ -2602,6 +3181,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       ExtendedDescriptor raw);
 
   @protected
+  int cst_encode_RustOpaque_bdkdescriptorPolicy(Policy raw);
+
+  @protected
   int cst_encode_RustOpaque_bdkkeysDescriptorPublicKey(DescriptorPublicKey raw);
 
   @protected
@@ -2658,6 +3240,18 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   int cst_encode_word_count(WordCount raw);
 
   @protected
+  void sse_encode_Map_String_list_prim_usize_strict(
+      Map<String, Uint64List> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_Map_list_prim_u_32_strict_list_condition(
+      Map<Uint32List, List<Condition>> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_Map_u_32_list_condition(
+      Map<int, List<Condition>> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_RustOpaque_bdkbitcoinAddress(
       Address self, SseSerializer serializer);
 
@@ -2672,6 +3266,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_RustOpaque_bdkdescriptorExtendedDescriptor(
       ExtendedDescriptor self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_RustOpaque_bdkdescriptorPolicy(
+      Policy self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_bdkkeysDescriptorPublicKey(
@@ -2741,6 +3339,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_bdk_mnemonic(BdkMnemonic self, SseSerializer serializer);
 
   @protected
+  void sse_encode_bdk_policy(BdkPolicy self, SseSerializer serializer);
+
+  @protected
   void sse_encode_bdk_psbt(BdkPsbt self, SseSerializer serializer);
 
   @protected
@@ -2800,6 +3401,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       BdkMnemonic self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_bdk_policy(
+      BdkPolicy self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_bdk_psbt(BdkPsbt self, SseSerializer serializer);
 
   @protected
@@ -2821,6 +3426,13 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_box_autoadd_blockchain_config(
       BlockchainConfig self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_bool(bool self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_condition(
+      Condition self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_consensus_error(
@@ -2863,6 +3475,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_box_autoadd_out_point(
       OutPoint self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_pk_or_f(PkOrF self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_psbt_sig_hash_type(
@@ -2910,6 +3525,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       ChangeSpendPolicy self, SseSerializer serializer);
 
   @protected
+  void sse_encode_condition(Condition self, SseSerializer serializer);
+
+  @protected
   void sse_encode_consensus_error(
       ConsensusError self, SseSerializer serializer);
 
@@ -2947,6 +3565,14 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_keychain_kind(KeychainKind self, SseSerializer serializer);
 
   @protected
+  void sse_encode_list_bdk_policy(
+      List<BdkPolicy> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_condition(
+      List<Condition> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_list_prim_u_8_strict(
       List<Uint8List> self, SseSerializer serializer);
 
@@ -2958,11 +3584,38 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_list_out_point(List<OutPoint> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_list_pk_or_f(List<PkOrF> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_32_strict(
+      Uint32List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_64_strict(
+      Uint64List self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_u_8_strict(
       Uint8List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_usize_strict(
+      Uint64List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_record_list_prim_u_32_strict_list_condition(
+      List<(Uint32List, List<Condition>)> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_record_string_list_prim_usize_strict(
+      List<(String, Uint64List)> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_record_u_32_list_condition(
+      List<(int, List<Condition>)> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_script_amount(
@@ -2988,6 +3641,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_network(Network self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_Map_String_list_prim_usize_strict(
+      Map<String, Uint64List>? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer);
 
   @protected
@@ -2997,6 +3654,10 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   @protected
   void sse_encode_opt_box_autoadd_bdk_descriptor(
       BdkDescriptor? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_bdk_policy(
+      BdkPolicy? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_bdk_script_buf(
@@ -3011,11 +3672,18 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       BlockTime? self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_box_autoadd_f_32(double? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_fee_rate(
       FeeRate? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_lock_time(
+      LockTime? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_psbt_sig_hash_type(
@@ -3053,6 +3721,9 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
   void sse_encode_payload(Payload self, SseSerializer serializer);
 
   @protected
+  void sse_encode_pk_or_f(PkOrF self, SseSerializer serializer);
+
+  @protected
   void sse_encode_psbt_sig_hash_type(
       PsbtSigHashType self, SseSerializer serializer);
 
@@ -3068,14 +3739,33 @@ abstract class coreApiImplPlatform extends BaseApiImpl<coreWire> {
       (BdkPsbt, TransactionDetails) self, SseSerializer serializer);
 
   @protected
+  void sse_encode_record_list_prim_u_32_strict_list_condition(
+      (Uint32List, List<Condition>) self, SseSerializer serializer);
+
+  @protected
   void sse_encode_record_out_point_input_usize(
       (OutPoint, Input, BigInt) self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_record_string_list_prim_usize_strict(
+      (String, Uint64List) self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_record_u_32_list_condition(
+      (int, List<Condition>) self, SseSerializer serializer);
 
   @protected
   void sse_encode_rpc_config(RpcConfig self, SseSerializer serializer);
 
   @protected
   void sse_encode_rpc_sync_params(RpcSyncParams self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_satisfaction(Satisfaction self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_satisfiable_item(
+      SatisfiableItem self, SseSerializer serializer);
 
   @protected
   void sse_encode_script_amount(ScriptAmount self, SseSerializer serializer);
@@ -4267,6 +4957,102 @@ class coreWire implements BaseWire {
       _wire__crate__api__types__bdk_address_to_qr_uriPtr.asFunction<
           WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_address>)>();
 
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_as_string(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_as_string(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_as_stringPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string');
+  late final _wire__crate__api__types__bdk_policy_as_string =
+      _wire__crate__api__types__bdk_policy_as_stringPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_contribution(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_contribution(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_contributionPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution');
+  late final _wire__crate__api__types__bdk_policy_contribution =
+      _wire__crate__api__types__bdk_policy_contributionPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_id(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_id(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_idPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id');
+  late final _wire__crate__api__types__bdk_policy_id =
+      _wire__crate__api__types__bdk_policy_idPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_item(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_item(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_itemPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item');
+  late final _wire__crate__api__types__bdk_policy_item =
+      _wire__crate__api__types__bdk_policy_itemPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_requires_path(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_requires_path(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_requires_pathPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path');
+  late final _wire__crate__api__types__bdk_policy_requires_path =
+      _wire__crate__api__types__bdk_policy_requires_pathPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
+  WireSyncRust2DartDco wire__crate__api__types__bdk_policy_satisfaction(
+    ffi.Pointer<wire_cst_bdk_policy> that,
+  ) {
+    return _wire__crate__api__types__bdk_policy_satisfaction(
+      that,
+    );
+  }
+
+  late final _wire__crate__api__types__bdk_policy_satisfactionPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>>(
+      'frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction');
+  late final _wire__crate__api__types__bdk_policy_satisfaction =
+      _wire__crate__api__types__bdk_policy_satisfactionPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_bdk_policy>)>();
+
   WireSyncRust2DartDco wire__crate__api__types__bdk_script_buf_as_string(
     ffi.Pointer<wire_cst_bdk_script_buf> that,
   ) {
@@ -4838,6 +5624,26 @@ class coreWire implements BaseWire {
               int,
               ffi.Pointer<wire_cst_database_config>)>();
 
+  WireSyncRust2DartDco wire__crate__api__wallet__bdk_wallet_policies(
+    ffi.Pointer<wire_cst_bdk_wallet> ptr,
+    int keychain,
+  ) {
+    return _wire__crate__api__wallet__bdk_wallet_policies(
+      ptr,
+      keychain,
+    );
+  }
+
+  late final _wire__crate__api__wallet__bdk_wallet_policiesPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_bdk_wallet>, ffi.Int32)>>(
+      'frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies');
+  late final _wire__crate__api__wallet__bdk_wallet_policies =
+      _wire__crate__api__wallet__bdk_wallet_policiesPtr.asFunction<
+          WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_bdk_wallet>, int)>();
+
   void wire__crate__api__wallet__bdk_wallet_sign(
     int port_,
     ffi.Pointer<wire_cst_bdk_wallet> ptr,
@@ -4946,6 +5752,10 @@ class coreWire implements BaseWire {
     bool drain_wallet,
     ffi.Pointer<wire_cst_bdk_script_buf> drain_to,
     ffi.Pointer<wire_cst_rbf_value> rbf,
+    ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+        internal_policy_path,
+    ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+        external_policy_path,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
   ) {
     return _wire__crate__api__wallet__tx_builder_finish(
@@ -4962,28 +5772,35 @@ class coreWire implements BaseWire {
       drain_wallet,
       drain_to,
       rbf,
+      internal_policy_path,
+      external_policy_path,
       data,
     );
   }
 
-  late final _wire__crate__api__wallet__tx_builder_finishPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64,
-                  ffi.Pointer<wire_cst_bdk_wallet>,
-                  ffi.Pointer<wire_cst_list_script_amount>,
-                  ffi.Pointer<wire_cst_list_out_point>,
-                  ffi.Pointer<wire_cst_record_out_point_input_usize>,
-                  ffi.Pointer<wire_cst_list_out_point>,
-                  ffi.Int32,
-                  ffi.Bool,
-                  ffi.Pointer<ffi.Float>,
-                  ffi.Pointer<ffi.Uint64>,
-                  ffi.Bool,
-                  ffi.Pointer<wire_cst_bdk_script_buf>,
-                  ffi.Pointer<wire_cst_rbf_value>,
-                  ffi.Pointer<wire_cst_list_prim_u_8_loose>)>>(
-      'frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish');
+  late final _wire__crate__api__wallet__tx_builder_finishPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Int64,
+                      ffi.Pointer<wire_cst_bdk_wallet>,
+                      ffi.Pointer<wire_cst_list_script_amount>,
+                      ffi.Pointer<wire_cst_list_out_point>,
+                      ffi.Pointer<wire_cst_record_out_point_input_usize>,
+                      ffi.Pointer<wire_cst_list_out_point>,
+                      ffi.Int32,
+                      ffi.Bool,
+                      ffi.Pointer<ffi.Float>,
+                      ffi.Pointer<ffi.Uint64>,
+                      ffi.Bool,
+                      ffi.Pointer<wire_cst_bdk_script_buf>,
+                      ffi.Pointer<wire_cst_rbf_value>,
+                      ffi.Pointer<
+                          wire_cst_list_record_string_list_prim_usize_strict>,
+                      ffi.Pointer<
+                          wire_cst_list_record_string_list_prim_usize_strict>,
+                      ffi.Pointer<wire_cst_list_prim_u_8_loose>)>>(
+          'frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish');
   late final _wire__crate__api__wallet__tx_builder_finish =
       _wire__crate__api__wallet__tx_builder_finishPtr.asFunction<
           void Function(
@@ -5000,6 +5817,8 @@ class coreWire implements BaseWire {
               bool,
               ffi.Pointer<wire_cst_bdk_script_buf>,
               ffi.Pointer<wire_cst_rbf_value>,
+              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>,
+              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>)>();
 
   void rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(
@@ -5122,6 +5941,36 @@ class coreWire implements BaseWire {
           'frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor');
   late final _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor =
       _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptorPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy');
+  late final _rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy =
+      _rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicyPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy');
+  late final _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy =
+      _rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicyPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorPublicKey(
@@ -5413,6 +6262,17 @@ class coreWire implements BaseWire {
       _cst_new_box_autoadd_bdk_mnemonicPtr
           .asFunction<ffi.Pointer<wire_cst_bdk_mnemonic> Function()>();
 
+  ffi.Pointer<wire_cst_bdk_policy> cst_new_box_autoadd_bdk_policy() {
+    return _cst_new_box_autoadd_bdk_policy();
+  }
+
+  late final _cst_new_box_autoadd_bdk_policyPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_bdk_policy> Function()>>(
+          'frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy');
+  late final _cst_new_box_autoadd_bdk_policy =
+      _cst_new_box_autoadd_bdk_policyPtr
+          .asFunction<ffi.Pointer<wire_cst_bdk_policy> Function()>();
+
   ffi.Pointer<wire_cst_bdk_psbt> cst_new_box_autoadd_bdk_psbt() {
     return _cst_new_box_autoadd_bdk_psbt();
   }
@@ -5479,6 +6339,30 @@ class coreWire implements BaseWire {
   late final _cst_new_box_autoadd_blockchain_config =
       _cst_new_box_autoadd_blockchain_configPtr
           .asFunction<ffi.Pointer<wire_cst_blockchain_config> Function()>();
+
+  ffi.Pointer<ffi.Bool> cst_new_box_autoadd_bool(
+    bool value,
+  ) {
+    return _cst_new_box_autoadd_bool(
+      value,
+    );
+  }
+
+  late final _cst_new_box_autoadd_boolPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
+          'frbgen_bdk_flutter_cst_new_box_autoadd_bool');
+  late final _cst_new_box_autoadd_bool = _cst_new_box_autoadd_boolPtr
+      .asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+
+  ffi.Pointer<wire_cst_condition> cst_new_box_autoadd_condition() {
+    return _cst_new_box_autoadd_condition();
+  }
+
+  late final _cst_new_box_autoadd_conditionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_condition> Function()>>(
+          'frbgen_bdk_flutter_cst_new_box_autoadd_condition');
+  late final _cst_new_box_autoadd_condition = _cst_new_box_autoadd_conditionPtr
+      .asFunction<ffi.Pointer<wire_cst_condition> Function()>();
 
   ffi.Pointer<wire_cst_consensus_error> cst_new_box_autoadd_consensus_error() {
     return _cst_new_box_autoadd_consensus_error();
@@ -5601,6 +6485,16 @@ class coreWire implements BaseWire {
           'frbgen_bdk_flutter_cst_new_box_autoadd_out_point');
   late final _cst_new_box_autoadd_out_point = _cst_new_box_autoadd_out_pointPtr
       .asFunction<ffi.Pointer<wire_cst_out_point> Function()>();
+
+  ffi.Pointer<wire_cst_pk_or_f> cst_new_box_autoadd_pk_or_f() {
+    return _cst_new_box_autoadd_pk_or_f();
+  }
+
+  late final _cst_new_box_autoadd_pk_or_fPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pk_or_f> Function()>>(
+          'frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f');
+  late final _cst_new_box_autoadd_pk_or_f = _cst_new_box_autoadd_pk_or_fPtr
+      .asFunction<ffi.Pointer<wire_cst_pk_or_f> Function()>();
 
   ffi.Pointer<wire_cst_psbt_sig_hash_type>
       cst_new_box_autoadd_psbt_sig_hash_type() {
@@ -5739,6 +6633,36 @@ class coreWire implements BaseWire {
   late final _cst_new_box_autoadd_u_8 = _cst_new_box_autoadd_u_8Ptr
       .asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_bdk_policy> cst_new_list_bdk_policy(
+    int len,
+  ) {
+    return _cst_new_list_bdk_policy(
+      len,
+    );
+  }
+
+  late final _cst_new_list_bdk_policyPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_bdk_policy> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_bdk_policy');
+  late final _cst_new_list_bdk_policy = _cst_new_list_bdk_policyPtr
+      .asFunction<ffi.Pointer<wire_cst_list_bdk_policy> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_condition> cst_new_list_condition(
+    int len,
+  ) {
+    return _cst_new_list_condition(
+      len,
+    );
+  }
+
+  late final _cst_new_list_conditionPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_condition> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_condition');
+  late final _cst_new_list_condition = _cst_new_list_conditionPtr
+      .asFunction<ffi.Pointer<wire_cst_list_condition> Function(int)>();
+
   ffi.Pointer<wire_cst_list_list_prim_u_8_strict>
       cst_new_list_list_prim_u_8_strict(
     int len,
@@ -5787,6 +6711,51 @@ class coreWire implements BaseWire {
   late final _cst_new_list_out_point = _cst_new_list_out_pointPtr
       .asFunction<ffi.Pointer<wire_cst_list_out_point> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_pk_or_f> cst_new_list_pk_or_f(
+    int len,
+  ) {
+    return _cst_new_list_pk_or_f(
+      len,
+    );
+  }
+
+  late final _cst_new_list_pk_or_fPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_pk_or_f> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_pk_or_f');
+  late final _cst_new_list_pk_or_f = _cst_new_list_pk_or_fPtr
+      .asFunction<ffi.Pointer<wire_cst_list_pk_or_f> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_prim_u_32_strict> cst_new_list_prim_u_32_strict(
+    int len,
+  ) {
+    return _cst_new_list_prim_u_32_strict(
+      len,
+    );
+  }
+
+  late final _cst_new_list_prim_u_32_strictPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_prim_u_32_strict> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_prim_u_32_strict');
+  late final _cst_new_list_prim_u_32_strict = _cst_new_list_prim_u_32_strictPtr
+      .asFunction<ffi.Pointer<wire_cst_list_prim_u_32_strict> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_prim_u_64_strict> cst_new_list_prim_u_64_strict(
+    int len,
+  ) {
+    return _cst_new_list_prim_u_64_strict(
+      len,
+    );
+  }
+
+  late final _cst_new_list_prim_u_64_strictPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_prim_u_64_strict> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_prim_u_64_strict');
+  late final _cst_new_list_prim_u_64_strict = _cst_new_list_prim_u_64_strictPtr
+      .asFunction<ffi.Pointer<wire_cst_list_prim_u_64_strict> Function(int)>();
+
   ffi.Pointer<wire_cst_list_prim_u_8_loose> cst_new_list_prim_u_8_loose(
     int len,
   ) {
@@ -5816,6 +6785,80 @@ class coreWire implements BaseWire {
               ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_prim_u_8_strict');
   late final _cst_new_list_prim_u_8_strict = _cst_new_list_prim_u_8_strictPtr
       .asFunction<ffi.Pointer<wire_cst_list_prim_u_8_strict> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_prim_usize_strict> cst_new_list_prim_usize_strict(
+    int len,
+  ) {
+    return _cst_new_list_prim_usize_strict(
+      len,
+    );
+  }
+
+  late final _cst_new_list_prim_usize_strictPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_prim_usize_strict> Function(
+              ffi.Int32)>>('frbgen_bdk_flutter_cst_new_list_prim_usize_strict');
+  late final _cst_new_list_prim_usize_strict =
+      _cst_new_list_prim_usize_strictPtr.asFunction<
+          ffi.Pointer<wire_cst_list_prim_usize_strict> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
+      cst_new_list_record_list_prim_u_32_strict_list_condition(
+    int len,
+  ) {
+    return _cst_new_list_record_list_prim_u_32_strict_list_condition(
+      len,
+    );
+  }
+
+  late final _cst_new_list_record_list_prim_u_32_strict_list_conditionPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<
+                      wire_cst_list_record_list_prim_u_32_strict_list_condition>
+                  Function(ffi.Int32)>>(
+      'frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition');
+  late final _cst_new_list_record_list_prim_u_32_strict_list_condition =
+      _cst_new_list_record_list_prim_u_32_strict_list_conditionPtr.asFunction<
+          ffi.Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
+              Function(int)>();
+
+  ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+      cst_new_list_record_string_list_prim_usize_strict(
+    int len,
+  ) {
+    return _cst_new_list_record_string_list_prim_usize_strict(
+      len,
+    );
+  }
+
+  late final _cst_new_list_record_string_list_prim_usize_strictPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+                  Function(ffi.Int32)>>(
+      'frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict');
+  late final _cst_new_list_record_string_list_prim_usize_strict =
+      _cst_new_list_record_string_list_prim_usize_strictPtr.asFunction<
+          ffi.Pointer<wire_cst_list_record_string_list_prim_usize_strict>
+              Function(int)>();
+
+  ffi.Pointer<wire_cst_list_record_u_32_list_condition>
+      cst_new_list_record_u_32_list_condition(
+    int len,
+  ) {
+    return _cst_new_list_record_u_32_list_condition(
+      len,
+    );
+  }
+
+  late final _cst_new_list_record_u_32_list_conditionPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<wire_cst_list_record_u_32_list_condition> Function(
+                  ffi.Int32)>>(
+      'frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition');
+  late final _cst_new_list_record_u_32_list_condition =
+      _cst_new_list_record_u_32_list_conditionPtr.asFunction<
+          ffi.Pointer<wire_cst_list_record_u_32_list_condition> Function(
+              int)>();
 
   ffi.Pointer<wire_cst_list_script_amount> cst_new_list_script_amount(
     int len,
@@ -6072,6 +7115,11 @@ final class wire_cst_bdk_script_buf extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bytes;
 }
 
+final class wire_cst_bdk_policy extends ffi.Struct {
+  @ffi.UintPtr()
+  external int ptr;
+}
+
 final class wire_cst_LockTime_Blocks extends ffi.Struct {
   @ffi.Uint32()
   external int field0;
@@ -6289,6 +7337,27 @@ final class wire_cst_rbf_value extends ffi.Struct {
   external RbfValueKind kind;
 }
 
+final class wire_cst_list_prim_usize_strict extends ffi.Struct {
+  external ffi.Pointer<ffi.UintPtr> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_record_string_list_prim_usize_strict extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+
+  external ffi.Pointer<wire_cst_list_prim_usize_strict> field1;
+}
+
+final class wire_cst_list_record_string_list_prim_usize_strict
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_record_string_list_prim_usize_strict> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_AddressError_Base58 extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
@@ -6376,6 +7445,12 @@ final class wire_cst_block_time extends ffi.Struct {
 
   @ffi.Uint64()
   external int timestamp;
+}
+
+final class wire_cst_condition extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint32> csv;
+
+  external ffi.Pointer<wire_cst_lock_time> timelock;
 }
 
 final class wire_cst_ConsensusError_Io extends ffi.Struct {
@@ -6524,8 +7599,100 @@ final class wire_cst_hex_error extends ffi.Struct {
   external HexErrorKind kind;
 }
 
+final class wire_cst_PkOrF_Pubkey extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> value;
+}
+
+final class wire_cst_PkOrF_XOnlyPubkey extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> value;
+}
+
+final class wire_cst_PkOrF_Fingerprint extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> value;
+}
+
+final class PkOrFKind extends ffi.Union {
+  external wire_cst_PkOrF_Pubkey Pubkey;
+
+  external wire_cst_PkOrF_XOnlyPubkey XOnlyPubkey;
+
+  external wire_cst_PkOrF_Fingerprint Fingerprint;
+}
+
+final class wire_cst_pk_or_f extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external PkOrFKind kind;
+}
+
+final class wire_cst_list_bdk_policy extends ffi.Struct {
+  external ffi.Pointer<wire_cst_bdk_policy> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_list_condition extends ffi.Struct {
+  external ffi.Pointer<wire_cst_condition> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_list_local_utxo extends ffi.Struct {
   external ffi.Pointer<wire_cst_local_utxo> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_list_pk_or_f extends ffi.Struct {
+  external ffi.Pointer<wire_cst_pk_or_f> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_list_prim_u_32_strict extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint32> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_list_prim_u_64_strict extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint64> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_record_list_prim_u_32_strict_list_condition
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_32_strict> field0;
+
+  external ffi.Pointer<wire_cst_list_condition> field1;
+}
+
+final class wire_cst_list_record_list_prim_u_32_strict_list_condition
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_record_list_prim_u_32_strict_list_condition>
+      ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_record_u_32_list_condition extends ffi.Struct {
+  @ffi.Uint32()
+  external int field0;
+
+  external ffi.Pointer<wire_cst_list_condition> field1;
+}
+
+final class wire_cst_list_record_u_32_list_condition extends ffi.Struct {
+  external ffi.Pointer<wire_cst_record_u_32_list_condition> ptr;
 
   @ffi.Int32()
   external int len;
@@ -6856,4 +8023,135 @@ final class wire_cst_record_bdk_psbt_transaction_details extends ffi.Struct {
   external wire_cst_bdk_psbt field0;
 
   external wire_cst_transaction_details field1;
+}
+
+final class wire_cst_Satisfaction_Partial extends ffi.Struct {
+  @ffi.Uint64()
+  external int n;
+
+  @ffi.Uint64()
+  external int m;
+
+  external ffi.Pointer<wire_cst_list_prim_u_64_strict> items;
+
+  external ffi.Pointer<ffi.Bool> sorted;
+
+  external ffi.Pointer<wire_cst_list_record_u_32_list_condition> conditions;
+}
+
+final class wire_cst_Satisfaction_PartialComplete extends ffi.Struct {
+  @ffi.Uint64()
+  external int n;
+
+  @ffi.Uint64()
+  external int m;
+
+  external ffi.Pointer<wire_cst_list_prim_u_64_strict> items;
+
+  external ffi.Pointer<ffi.Bool> sorted;
+
+  external ffi
+      .Pointer<wire_cst_list_record_list_prim_u_32_strict_list_condition>
+      conditions;
+}
+
+final class wire_cst_Satisfaction_Complete extends ffi.Struct {
+  external ffi.Pointer<wire_cst_condition> condition;
+}
+
+final class wire_cst_Satisfaction_None extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> msg;
+}
+
+final class SatisfactionKind extends ffi.Union {
+  external wire_cst_Satisfaction_Partial Partial;
+
+  external wire_cst_Satisfaction_PartialComplete PartialComplete;
+
+  external wire_cst_Satisfaction_Complete Complete;
+
+  external wire_cst_Satisfaction_None None;
+}
+
+final class wire_cst_satisfaction extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SatisfactionKind kind;
+}
+
+final class wire_cst_SatisfiableItem_EcdsaSignature extends ffi.Struct {
+  external ffi.Pointer<wire_cst_pk_or_f> key;
+}
+
+final class wire_cst_SatisfiableItem_SchnorrSignature extends ffi.Struct {
+  external ffi.Pointer<wire_cst_pk_or_f> key;
+}
+
+final class wire_cst_SatisfiableItem_Sha256Preimage extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
+final class wire_cst_SatisfiableItem_Hash256Preimage extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
+final class wire_cst_SatisfiableItem_Ripemd160Preimage extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
+final class wire_cst_SatisfiableItem_Hash160Preimage extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
+final class wire_cst_SatisfiableItem_AbsoluteTimelock extends ffi.Struct {
+  external ffi.Pointer<wire_cst_lock_time> value;
+}
+
+final class wire_cst_SatisfiableItem_RelativeTimelock extends ffi.Struct {
+  @ffi.Uint32()
+  external int value;
+}
+
+final class wire_cst_SatisfiableItem_Multisig extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_pk_or_f> keys;
+
+  @ffi.Uint64()
+  external int threshold;
+}
+
+final class wire_cst_SatisfiableItem_Thresh extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_bdk_policy> items;
+
+  @ffi.Uint64()
+  external int threshold;
+}
+
+final class SatisfiableItemKind extends ffi.Union {
+  external wire_cst_SatisfiableItem_EcdsaSignature EcdsaSignature;
+
+  external wire_cst_SatisfiableItem_SchnorrSignature SchnorrSignature;
+
+  external wire_cst_SatisfiableItem_Sha256Preimage Sha256Preimage;
+
+  external wire_cst_SatisfiableItem_Hash256Preimage Hash256Preimage;
+
+  external wire_cst_SatisfiableItem_Ripemd160Preimage Ripemd160Preimage;
+
+  external wire_cst_SatisfiableItem_Hash160Preimage Hash160Preimage;
+
+  external wire_cst_SatisfiableItem_AbsoluteTimelock AbsoluteTimelock;
+
+  external wire_cst_SatisfiableItem_RelativeTimelock RelativeTimelock;
+
+  external wire_cst_SatisfiableItem_Multisig Multisig;
+
+  external wire_cst_SatisfiableItem_Thresh Thresh;
+}
+
+final class wire_cst_satisfiable_item extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SatisfiableItemKind kind;
 }

--- a/lib/src/generated/lib.dart
+++ b/lib/src/generated/lib.dart
@@ -19,6 +19,9 @@ abstract class AnyBlockchain implements RustOpaqueInterface {}
 // Rust type: RustOpaqueNom<bdk :: descriptor :: ExtendedDescriptor>
 abstract class ExtendedDescriptor implements RustOpaqueInterface {}
 
+// Rust type: RustOpaqueNom<bdk :: descriptor :: Policy>
+abstract class Policy implements RustOpaqueInterface {}
+
 // Rust type: RustOpaqueNom<bdk :: keys :: DescriptorPublicKey>
 abstract class DescriptorPublicKey implements RustOpaqueInterface {}
 

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -139,6 +139,10 @@ typedef struct wire_cst_bdk_script_buf {
   struct wire_cst_list_prim_u_8_strict *bytes;
 } wire_cst_bdk_script_buf;
 
+typedef struct wire_cst_bdk_policy {
+  uintptr_t ptr;
+} wire_cst_bdk_policy;
+
 typedef struct wire_cst_LockTime_Blocks {
   uint32_t field0;
 } wire_cst_LockTime_Blocks;
@@ -297,6 +301,21 @@ typedef struct wire_cst_rbf_value {
   union RbfValueKind kind;
 } wire_cst_rbf_value;
 
+typedef struct wire_cst_list_prim_usize_strict {
+  uintptr_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_usize_strict;
+
+typedef struct wire_cst_record_string_list_prim_usize_strict {
+  struct wire_cst_list_prim_u_8_strict *field0;
+  struct wire_cst_list_prim_usize_strict *field1;
+} wire_cst_record_string_list_prim_usize_strict;
+
+typedef struct wire_cst_list_record_string_list_prim_usize_strict {
+  struct wire_cst_record_string_list_prim_usize_strict *ptr;
+  int32_t len;
+} wire_cst_list_record_string_list_prim_usize_strict;
+
 typedef struct wire_cst_AddressError_Base58 {
   struct wire_cst_list_prim_u_8_strict *field0;
 } wire_cst_AddressError_Base58;
@@ -357,6 +376,11 @@ typedef struct wire_cst_block_time {
   uint32_t height;
   uint64_t timestamp;
 } wire_cst_block_time;
+
+typedef struct wire_cst_condition {
+  uint32_t *csv;
+  struct wire_cst_lock_time *timelock;
+} wire_cst_condition;
 
 typedef struct wire_cst_ConsensusError_Io {
   struct wire_cst_list_prim_u_8_strict *field0;
@@ -469,10 +493,78 @@ typedef struct wire_cst_hex_error {
   union HexErrorKind kind;
 } wire_cst_hex_error;
 
+typedef struct wire_cst_PkOrF_Pubkey {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_Pubkey;
+
+typedef struct wire_cst_PkOrF_XOnlyPubkey {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_XOnlyPubkey;
+
+typedef struct wire_cst_PkOrF_Fingerprint {
+  struct wire_cst_list_prim_u_8_strict *value;
+} wire_cst_PkOrF_Fingerprint;
+
+typedef union PkOrFKind {
+  struct wire_cst_PkOrF_Pubkey Pubkey;
+  struct wire_cst_PkOrF_XOnlyPubkey XOnlyPubkey;
+  struct wire_cst_PkOrF_Fingerprint Fingerprint;
+} PkOrFKind;
+
+typedef struct wire_cst_pk_or_f {
+  int32_t tag;
+  union PkOrFKind kind;
+} wire_cst_pk_or_f;
+
+typedef struct wire_cst_list_bdk_policy {
+  struct wire_cst_bdk_policy *ptr;
+  int32_t len;
+} wire_cst_list_bdk_policy;
+
+typedef struct wire_cst_list_condition {
+  struct wire_cst_condition *ptr;
+  int32_t len;
+} wire_cst_list_condition;
+
 typedef struct wire_cst_list_local_utxo {
   struct wire_cst_local_utxo *ptr;
   int32_t len;
 } wire_cst_list_local_utxo;
+
+typedef struct wire_cst_list_pk_or_f {
+  struct wire_cst_pk_or_f *ptr;
+  int32_t len;
+} wire_cst_list_pk_or_f;
+
+typedef struct wire_cst_list_prim_u_32_strict {
+  uint32_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_u_32_strict;
+
+typedef struct wire_cst_list_prim_u_64_strict {
+  uint64_t *ptr;
+  int32_t len;
+} wire_cst_list_prim_u_64_strict;
+
+typedef struct wire_cst_record_list_prim_u_32_strict_list_condition {
+  struct wire_cst_list_prim_u_32_strict *field0;
+  struct wire_cst_list_condition *field1;
+} wire_cst_record_list_prim_u_32_strict_list_condition;
+
+typedef struct wire_cst_list_record_list_prim_u_32_strict_list_condition {
+  struct wire_cst_record_list_prim_u_32_strict_list_condition *ptr;
+  int32_t len;
+} wire_cst_list_record_list_prim_u_32_strict_list_condition;
+
+typedef struct wire_cst_record_u_32_list_condition {
+  uint32_t field0;
+  struct wire_cst_list_condition *field1;
+} wire_cst_record_u_32_list_condition;
+
+typedef struct wire_cst_list_record_u_32_list_condition {
+  struct wire_cst_record_u_32_list_condition *ptr;
+  int32_t len;
+} wire_cst_list_record_u_32_list_condition;
 
 typedef struct wire_cst_transaction_details {
   struct wire_cst_bdk_transaction *transaction;
@@ -722,6 +814,102 @@ typedef struct wire_cst_record_bdk_psbt_transaction_details {
   struct wire_cst_transaction_details field1;
 } wire_cst_record_bdk_psbt_transaction_details;
 
+typedef struct wire_cst_Satisfaction_Partial {
+  uint64_t n;
+  uint64_t m;
+  struct wire_cst_list_prim_u_64_strict *items;
+  bool *sorted;
+  struct wire_cst_list_record_u_32_list_condition *conditions;
+} wire_cst_Satisfaction_Partial;
+
+typedef struct wire_cst_Satisfaction_PartialComplete {
+  uint64_t n;
+  uint64_t m;
+  struct wire_cst_list_prim_u_64_strict *items;
+  bool *sorted;
+  struct wire_cst_list_record_list_prim_u_32_strict_list_condition *conditions;
+} wire_cst_Satisfaction_PartialComplete;
+
+typedef struct wire_cst_Satisfaction_Complete {
+  struct wire_cst_condition *condition;
+} wire_cst_Satisfaction_Complete;
+
+typedef struct wire_cst_Satisfaction_None {
+  struct wire_cst_list_prim_u_8_strict *msg;
+} wire_cst_Satisfaction_None;
+
+typedef union SatisfactionKind {
+  struct wire_cst_Satisfaction_Partial Partial;
+  struct wire_cst_Satisfaction_PartialComplete PartialComplete;
+  struct wire_cst_Satisfaction_Complete Complete;
+  struct wire_cst_Satisfaction_None None;
+} SatisfactionKind;
+
+typedef struct wire_cst_satisfaction {
+  int32_t tag;
+  union SatisfactionKind kind;
+} wire_cst_satisfaction;
+
+typedef struct wire_cst_SatisfiableItem_EcdsaSignature {
+  struct wire_cst_pk_or_f *key;
+} wire_cst_SatisfiableItem_EcdsaSignature;
+
+typedef struct wire_cst_SatisfiableItem_SchnorrSignature {
+  struct wire_cst_pk_or_f *key;
+} wire_cst_SatisfiableItem_SchnorrSignature;
+
+typedef struct wire_cst_SatisfiableItem_Sha256Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Sha256Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Hash256Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Hash256Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Ripemd160Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Ripemd160Preimage;
+
+typedef struct wire_cst_SatisfiableItem_Hash160Preimage {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_SatisfiableItem_Hash160Preimage;
+
+typedef struct wire_cst_SatisfiableItem_AbsoluteTimelock {
+  struct wire_cst_lock_time *value;
+} wire_cst_SatisfiableItem_AbsoluteTimelock;
+
+typedef struct wire_cst_SatisfiableItem_RelativeTimelock {
+  uint32_t value;
+} wire_cst_SatisfiableItem_RelativeTimelock;
+
+typedef struct wire_cst_SatisfiableItem_Multisig {
+  struct wire_cst_list_pk_or_f *keys;
+  uint64_t threshold;
+} wire_cst_SatisfiableItem_Multisig;
+
+typedef struct wire_cst_SatisfiableItem_Thresh {
+  struct wire_cst_list_bdk_policy *items;
+  uint64_t threshold;
+} wire_cst_SatisfiableItem_Thresh;
+
+typedef union SatisfiableItemKind {
+  struct wire_cst_SatisfiableItem_EcdsaSignature EcdsaSignature;
+  struct wire_cst_SatisfiableItem_SchnorrSignature SchnorrSignature;
+  struct wire_cst_SatisfiableItem_Sha256Preimage Sha256Preimage;
+  struct wire_cst_SatisfiableItem_Hash256Preimage Hash256Preimage;
+  struct wire_cst_SatisfiableItem_Ripemd160Preimage Ripemd160Preimage;
+  struct wire_cst_SatisfiableItem_Hash160Preimage Hash160Preimage;
+  struct wire_cst_SatisfiableItem_AbsoluteTimelock AbsoluteTimelock;
+  struct wire_cst_SatisfiableItem_RelativeTimelock RelativeTimelock;
+  struct wire_cst_SatisfiableItem_Multisig Multisig;
+  struct wire_cst_SatisfiableItem_Thresh Thresh;
+} SatisfiableItemKind;
+
+typedef struct wire_cst_satisfiable_item {
+  int32_t tag;
+  union SatisfiableItemKind kind;
+} wire_cst_satisfiable_item;
+
 void frbgen_bdk_flutter_wire__crate__api__blockchain__bdk_blockchain_broadcast(int64_t port_,
                                                                                struct wire_cst_bdk_blockchain *that,
                                                                                struct wire_cst_bdk_transaction *transaction);
@@ -886,6 +1074,18 @@ WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_address_scr
 
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_address_to_qr_uri(struct wire_cst_bdk_address *that);
 
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path(struct wire_cst_bdk_policy *that);
+
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction(struct wire_cst_bdk_policy *that);
+
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_as_string(struct wire_cst_bdk_script_buf *that);
 
 WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_empty(void);
@@ -974,6 +1174,9 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_new(int64_t port_,
                                                                  int32_t network,
                                                                  struct wire_cst_database_config *database_config);
 
+WireSyncRust2DartDco frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies(struct wire_cst_bdk_wallet *ptr,
+                                                                                      int32_t keychain);
+
 void frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sign(int64_t port_,
                                                                   struct wire_cst_bdk_wallet *ptr,
                                                                   struct wire_cst_bdk_psbt *psbt,
@@ -1004,6 +1207,8 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish(int64_t port
                                                                     bool drain_wallet,
                                                                     struct wire_cst_bdk_script_buf *drain_to,
                                                                     struct wire_cst_rbf_value *rbf,
+                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *internal_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *external_policy_path,
                                                                     struct wire_cst_list_prim_u_8_loose *data);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(const void *ptr);
@@ -1021,6 +1226,10 @@ void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkblockchain
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor(const void *ptr);
 
 void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor(const void *ptr);
+
+void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy(const void *ptr);
+
+void frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy(const void *ptr);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorPublicKey(const void *ptr);
 
@@ -1064,6 +1273,8 @@ struct wire_cst_bdk_descriptor_secret_key *frbgen_bdk_flutter_cst_new_box_autoad
 
 struct wire_cst_bdk_mnemonic *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_mnemonic(void);
 
+struct wire_cst_bdk_policy *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy(void);
+
 struct wire_cst_bdk_psbt *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_psbt(void);
 
 struct wire_cst_bdk_script_buf *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_script_buf(void);
@@ -1075,6 +1286,10 @@ struct wire_cst_bdk_wallet *frbgen_bdk_flutter_cst_new_box_autoadd_bdk_wallet(vo
 struct wire_cst_block_time *frbgen_bdk_flutter_cst_new_box_autoadd_block_time(void);
 
 struct wire_cst_blockchain_config *frbgen_bdk_flutter_cst_new_box_autoadd_blockchain_config(void);
+
+bool *frbgen_bdk_flutter_cst_new_box_autoadd_bool(bool value);
+
+struct wire_cst_condition *frbgen_bdk_flutter_cst_new_box_autoadd_condition(void);
 
 struct wire_cst_consensus_error *frbgen_bdk_flutter_cst_new_box_autoadd_consensus_error(void);
 
@@ -1098,6 +1313,8 @@ struct wire_cst_lock_time *frbgen_bdk_flutter_cst_new_box_autoadd_lock_time(void
 
 struct wire_cst_out_point *frbgen_bdk_flutter_cst_new_box_autoadd_out_point(void);
 
+struct wire_cst_pk_or_f *frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f(void);
+
 struct wire_cst_psbt_sig_hash_type *frbgen_bdk_flutter_cst_new_box_autoadd_psbt_sig_hash_type(void);
 
 struct wire_cst_rbf_value *frbgen_bdk_flutter_cst_new_box_autoadd_rbf_value(void);
@@ -1120,15 +1337,33 @@ uint64_t *frbgen_bdk_flutter_cst_new_box_autoadd_u_64(uint64_t value);
 
 uint8_t *frbgen_bdk_flutter_cst_new_box_autoadd_u_8(uint8_t value);
 
+struct wire_cst_list_bdk_policy *frbgen_bdk_flutter_cst_new_list_bdk_policy(int32_t len);
+
+struct wire_cst_list_condition *frbgen_bdk_flutter_cst_new_list_condition(int32_t len);
+
 struct wire_cst_list_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_list_prim_u_8_strict(int32_t len);
 
 struct wire_cst_list_local_utxo *frbgen_bdk_flutter_cst_new_list_local_utxo(int32_t len);
 
 struct wire_cst_list_out_point *frbgen_bdk_flutter_cst_new_list_out_point(int32_t len);
 
+struct wire_cst_list_pk_or_f *frbgen_bdk_flutter_cst_new_list_pk_or_f(int32_t len);
+
+struct wire_cst_list_prim_u_32_strict *frbgen_bdk_flutter_cst_new_list_prim_u_32_strict(int32_t len);
+
+struct wire_cst_list_prim_u_64_strict *frbgen_bdk_flutter_cst_new_list_prim_u_64_strict(int32_t len);
+
 struct wire_cst_list_prim_u_8_loose *frbgen_bdk_flutter_cst_new_list_prim_u_8_loose(int32_t len);
 
 struct wire_cst_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(int32_t len);
+
+struct wire_cst_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_prim_usize_strict(int32_t len);
+
+struct wire_cst_list_record_list_prim_u_32_strict_list_condition *frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(int32_t len);
+
+struct wire_cst_list_record_string_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(int32_t len);
+
+struct wire_cst_list_record_u_32_list_condition *frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition(int32_t len);
 
 struct wire_cst_list_script_amount *frbgen_bdk_flutter_cst_new_list_script_amount(int32_t len);
 
@@ -1148,12 +1383,15 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_descriptor_public_key);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_descriptor_secret_key);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_mnemonic);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_psbt);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_script_buf);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_transaction);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bdk_wallet);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_block_time);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_blockchain_config);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_bool);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_consensus_error);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_database_config);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_descriptor_error);
@@ -1165,6 +1403,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_local_utxo);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_lock_time);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_out_point);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_psbt_sig_hash_type);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_rbf_value);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_record_out_point_input_usize);
@@ -1176,11 +1415,20 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_32);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_64);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_box_autoadd_u_8);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_bdk_policy);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_list_prim_u_8_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_local_utxo);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_out_point);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_pk_or_f);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_32_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_64_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_loose);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_script_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_transaction_details);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_tx_in);
@@ -1189,6 +1437,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkbitcoinbip32DerivationPath);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkblockchainAnyBlockchain);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysDescriptorPublicKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysDescriptorSecretKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkkeysKeyMap);
@@ -1199,6 +1448,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinbip32DerivationPath);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkblockchainAnyBlockchain);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorExtendedDescriptor);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorPublicKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysDescriptorSecretKey);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkkeysKeyMap);
@@ -1256,6 +1506,12 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_payload);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_script);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_address_to_qr_uri);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_as_string);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_empty);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_from_hex);
@@ -1284,6 +1540,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_list_unspent);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_network);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_new);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sign);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_wire__crate__api__wallet__finish_bump_fee_tx_builder);

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -301,20 +301,20 @@ typedef struct wire_cst_rbf_value {
   union RbfValueKind kind;
 } wire_cst_rbf_value;
 
-typedef struct wire_cst_list_prim_usize_strict {
-  uintptr_t *ptr;
+typedef struct wire_cst_list_prim_u_32_strict {
+  uint32_t *ptr;
   int32_t len;
-} wire_cst_list_prim_usize_strict;
+} wire_cst_list_prim_u_32_strict;
 
-typedef struct wire_cst_record_string_list_prim_usize_strict {
+typedef struct wire_cst_record_string_list_prim_u_32_strict {
   struct wire_cst_list_prim_u_8_strict *field0;
-  struct wire_cst_list_prim_usize_strict *field1;
-} wire_cst_record_string_list_prim_usize_strict;
+  struct wire_cst_list_prim_u_32_strict *field1;
+} wire_cst_record_string_list_prim_u_32_strict;
 
-typedef struct wire_cst_list_record_string_list_prim_usize_strict {
-  struct wire_cst_record_string_list_prim_usize_strict *ptr;
+typedef struct wire_cst_list_record_string_list_prim_u_32_strict {
+  struct wire_cst_record_string_list_prim_u_32_strict *ptr;
   int32_t len;
-} wire_cst_list_record_string_list_prim_usize_strict;
+} wire_cst_list_record_string_list_prim_u_32_strict;
 
 typedef struct wire_cst_AddressError_Base58 {
   struct wire_cst_list_prim_u_8_strict *field0;
@@ -535,11 +535,6 @@ typedef struct wire_cst_list_pk_or_f {
   struct wire_cst_pk_or_f *ptr;
   int32_t len;
 } wire_cst_list_pk_or_f;
-
-typedef struct wire_cst_list_prim_u_32_strict {
-  uint32_t *ptr;
-  int32_t len;
-} wire_cst_list_prim_u_32_strict;
 
 typedef struct wire_cst_list_prim_u_64_strict {
   uint64_t *ptr;
@@ -1207,8 +1202,8 @@ void frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish(int64_t port
                                                                     bool drain_wallet,
                                                                     struct wire_cst_bdk_script_buf *drain_to,
                                                                     struct wire_cst_rbf_value *rbf,
-                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *internal_policy_path,
-                                                                    struct wire_cst_list_record_string_list_prim_usize_strict *external_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_u_32_strict *internal_policy_path,
+                                                                    struct wire_cst_list_record_string_list_prim_u_32_strict *external_policy_path,
                                                                     struct wire_cst_list_prim_u_8_loose *data);
 
 void frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkbitcoinAddress(const void *ptr);
@@ -1357,11 +1352,9 @@ struct wire_cst_list_prim_u_8_loose *frbgen_bdk_flutter_cst_new_list_prim_u_8_lo
 
 struct wire_cst_list_prim_u_8_strict *frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(int32_t len);
 
-struct wire_cst_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_prim_usize_strict(int32_t len);
-
 struct wire_cst_list_record_list_prim_u_32_strict_list_condition *frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(int32_t len);
 
-struct wire_cst_list_record_string_list_prim_usize_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(int32_t len);
+struct wire_cst_list_record_string_list_prim_u_32_strict *frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict(int32_t len);
 
 struct wire_cst_list_record_u_32_list_condition *frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition(int32_t len);
 
@@ -1425,9 +1418,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_64_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_loose);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_u_8_strict);
-    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_prim_usize_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition);
-    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict);
+    dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_script_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_bdk_flutter_cst_new_list_transaction_details);

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -10,16 +10,15 @@ pub mod psbt;
 pub mod types;
 pub mod wallet;
 
-pub(crate) fn handle_mutex<T, F, R>(lock: &Mutex<T>, operation: F) -> Result<R, BdkError>
+pub(crate) fn execute_with_lock<T, F, R>(lock: &Mutex<T>, operation: F) -> Result<R, BdkError>
 where
     T: Debug,
     F: FnOnce(&mut T) -> R,
 {
-    match lock.lock() {
-        Ok(mut mutex_guard) => Ok(operation(&mut *mutex_guard)),
-        Err(poisoned) => {
+    lock.lock()
+        .map_err(|poisoned| {
             drop(poisoned.into_inner());
-            Err(BdkError::Generic("Poison Error!".to_string()))
-        }
-    }
+            BdkError::Generic("Poison Error!".to_string())
+        })
+        .map(|mut guard| operation(&mut *guard))
 }

--- a/rust/src/api/psbt.rs
+++ b/rust/src/api/psbt.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use flutter_rust_bridge::frb;
 
-use super::handle_mutex;
+use super::execute_with_lock;
 
 #[derive(Debug)]
 pub struct BdkPsbt {
@@ -31,7 +31,7 @@ impl BdkPsbt {
 
     #[frb(sync)]
     pub fn as_string(&self) -> Result<String, BdkError> {
-        handle_mutex(&self.ptr, |psbt| psbt.to_string())
+        execute_with_lock(&self.ptr, |psbt| psbt.to_string())
     }
 
     ///Computes the `Txid`.
@@ -39,7 +39,7 @@ impl BdkPsbt {
     /// For non-segwit transactions which do not have any segwit data, this will be equal to transaction.wtxid().
     #[frb(sync)]
     pub fn txid(&self) -> Result<String, BdkError> {
-        handle_mutex(&self.ptr, |psbt| {
+        execute_with_lock(&self.ptr, |psbt| {
             psbt.to_owned().extract_tx().txid().to_string()
         })
     }
@@ -47,7 +47,7 @@ impl BdkPsbt {
     /// Return the transaction.
     #[frb(sync)]
     pub fn extract_tx(ptr: BdkPsbt) -> Result<BdkTransaction, BdkError> {
-        handle_mutex(&ptr.ptr, |psbt| {
+        execute_with_lock(&ptr.ptr, |psbt| {
             let tx = psbt.to_owned().extract_tx();
             tx.try_into()
         })?
@@ -74,7 +74,7 @@ impl BdkPsbt {
     /// If the PSBT is missing a TxOut for an input returns None.
     #[frb(sync)]
     pub fn fee_amount(&self) -> Result<Option<u64>, BdkError> {
-        handle_mutex(&self.ptr, |psbt| psbt.fee_amount())
+        execute_with_lock(&self.ptr, |psbt| psbt.fee_amount())
     }
 
     /// The transaction's fee rate. This value will only be accurate if calculated AFTER the
@@ -83,18 +83,18 @@ impl BdkPsbt {
     /// If the PSBT is missing a TxOut for an input returns None.
     #[frb(sync)]
     pub fn fee_rate(&self) -> Result<Option<FeeRate>, BdkError> {
-        handle_mutex(&self.ptr, |psbt| psbt.fee_rate().map(|e| e.into()))
+        execute_with_lock(&self.ptr, |psbt| psbt.fee_rate().map(|e| e.into()))
     }
 
     ///Serialize as raw binary data
     #[frb(sync)]
     pub fn serialize(&self) -> Result<Vec<u8>, BdkError> {
-        handle_mutex(&self.ptr, |psbt| psbt.serialize())
+        execute_with_lock(&self.ptr, |psbt| psbt.serialize())
     }
     /// Serialize the PSBT data structure as a String of JSON.
     #[frb(sync)]
     pub fn json_serialize(&self) -> Result<String, BdkError> {
-        handle_mutex(&self.ptr, |psbt| {
+        execute_with_lock(&self.ptr, |psbt| {
             serde_json::to_string(psbt.deref()).map_err(|e| BdkError::Generic(e.to_string()))
         })?
     }

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -912,3 +912,19 @@ impl TryFrom<bdk::bitcoin::psbt::Input> for Input {
         })
     }
 }
+pub struct FfiPolicy {
+    pub opaque: RustOpaque<bdk::descriptor::Policy>,
+}
+impl FfiPolicy {
+    #[frb(sync)]
+    pub fn id(&self) -> String {
+        self.opaque.id.clone()
+    }
+}
+impl From<bdk::descriptor::Policy> for FfiPolicy {
+    fn from(value: bdk::descriptor::Policy) -> Self {
+        FfiPolicy {
+            opaque: RustOpaque::new(value),
+        }
+    }
+}

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -32,6 +32,7 @@ use bdk::database::ConfigurableDatabase;
 use flutter_rust_bridge::frb;
 
 use super::handle_mutex;
+use super::types::FfiPolicy;
 
 #[derive(Debug)]
 pub struct BdkWallet {
@@ -195,6 +196,14 @@ impl BdkWallet {
         handle_mutex(&ptr.ptr, |w| {
             let extended_descriptor = w.get_descriptor_for_keychain(keychain.into());
             BdkDescriptor::new(extended_descriptor.to_string(), w.network().into())
+        })?
+    }
+    #[frb(sync)]
+    pub fn policies(ptr: BdkWallet, keychain: KeychainKind) -> Result<Option<FfiPolicy>, BdkError> {
+        handle_mutex(&ptr.ptr, |w| {
+            w.policies(keychain.into())
+                .map_err(|e| e.into())
+                .map(|e| e.map(|f| f.into()))
         })?
     }
 }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -242,8 +242,8 @@ pub fn tx_builder_finish(
     drain_wallet: bool,
     drain_to: Option<BdkScriptBuf>,
     rbf: Option<RbfValue>,
-    internal_policy_path: Option<HashMap<String, Vec<usize>>>,
-    external_policy_path: Option<HashMap<String, Vec<usize>>>,
+    internal_policy_path: Option<HashMap<String, Vec<u32>>>,
+    external_policy_path: Option<HashMap<String, Vec<u32>>>,
     data: Vec<u8>,
 ) -> anyhow::Result<(BdkPsbt, TransactionDetails), BdkError> {
     execute_with_lock(&wallet.ptr, |w| {

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,22 +1,10 @@
 use crate::api::descriptor::BdkDescriptor;
 use crate::api::types::{
-    AddressIndex,
-    Balance,
-    BdkAddress,
-    BdkScriptBuf,
-    ChangeSpendPolicy,
-    DatabaseConfig,
-    Input,
-    KeychainKind,
-    LocalUtxo,
-    Network,
-    OutPoint,
-    PsbtSigHashType,
-    RbfValue,
-    ScriptAmount,
-    SignOptions,
-    TransactionDetails,
+    AddressIndex, Balance, BdkAddress, BdkScriptBuf, ChangeSpendPolicy, DatabaseConfig, Input,
+    KeychainKind, LocalUtxo, Network, OutPoint, PsbtSigHashType, RbfValue, ScriptAmount,
+    SignOptions, TransactionDetails,
 };
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -25,14 +13,14 @@ use crate::api::error::BdkError;
 use crate::api::psbt::BdkPsbt;
 use crate::frb_generated::RustOpaque;
 use bdk::bitcoin::script::PushBytesBuf;
-use bdk::bitcoin::{ Sequence, Txid };
+use bdk::bitcoin::{Sequence, Txid};
 pub use bdk::blockchain::GetTx;
 
 use bdk::database::ConfigurableDatabase;
 use flutter_rust_bridge::frb;
 
-use super::handle_mutex;
-use super::types::FfiPolicy;
+use super::execute_with_lock;
+use super::types::BdkPolicy;
 
 #[derive(Debug)]
 pub struct BdkWallet {
@@ -43,7 +31,7 @@ impl BdkWallet {
         descriptor: BdkDescriptor,
         change_descriptor: Option<BdkDescriptor>,
         network: Network,
-        database_config: DatabaseConfig
+        database_config: DatabaseConfig,
     ) -> Result<Self, BdkError> {
         let database = bdk::database::AnyDatabase::from_config(&database_config.into())?;
         let descriptor: String = descriptor.to_string_private();
@@ -53,7 +41,7 @@ impl BdkWallet {
             &descriptor,
             change_descriptor.as_ref(),
             network.into(),
-            database
+            database,
         )?;
         Ok(BdkWallet {
             ptr: RustOpaque::new(std::sync::Mutex::new(wallet)),
@@ -63,14 +51,13 @@ impl BdkWallet {
     /// Get the Bitcoin network the wallet is using.
     #[frb(sync)]
     pub fn network(&self) -> Result<Network, BdkError> {
-        handle_mutex(&self.ptr, |w| w.network().into())
+        execute_with_lock(&self.ptr, |w| w.network().into())
     }
     #[frb(sync)]
     pub fn is_mine(&self, script: BdkScriptBuf) -> Result<bool, BdkError> {
-        handle_mutex(&self.ptr, |w| {
-            w.is_mine(
-                <BdkScriptBuf as Into<bdk::bitcoin::ScriptBuf>>::into(script).as_script()
-            ).map_err(|e| e.into())
+        execute_with_lock(&self.ptr, |w| {
+            w.is_mine(<BdkScriptBuf as Into<bdk::bitcoin::ScriptBuf>>::into(script).as_script())
+                .map_err(|e| e.into())
         })?
     }
     /// Return a derived address using the external descriptor, see AddressIndex for available address index selection
@@ -79,9 +66,9 @@ impl BdkWallet {
     #[frb(sync)]
     pub fn get_address(
         ptr: BdkWallet,
-        address_index: AddressIndex
+        address_index: AddressIndex,
     ) -> Result<(BdkAddress, u32), BdkError> {
-        handle_mutex(&ptr.ptr, |w| {
+        execute_with_lock(&ptr.ptr, |w| {
             w.get_address(address_index.into())
                 .map(|e| (e.address.into(), e.index))
                 .map_err(|e| e.into())
@@ -98,9 +85,9 @@ impl BdkWallet {
     #[frb(sync)]
     pub fn get_internal_address(
         ptr: BdkWallet,
-        address_index: AddressIndex
+        address_index: AddressIndex,
     ) -> Result<(BdkAddress, u32), BdkError> {
-        handle_mutex(&ptr.ptr, |w| {
+        execute_with_lock(&ptr.ptr, |w| {
             w.get_internal_address(address_index.into())
                 .map(|e| (e.address.into(), e.index))
                 .map_err(|e| e.into())
@@ -111,19 +98,17 @@ impl BdkWallet {
     /// on the internal database, which first needs to be Wallet.sync manually.
     #[frb(sync)]
     pub fn get_balance(&self) -> Result<Balance, BdkError> {
-        handle_mutex(&self.ptr, |w| {
-            w.get_balance()
-                .map(|b| b.into())
-                .map_err(|e| e.into())
+        execute_with_lock(&self.ptr, |w| {
+            w.get_balance().map(|b| b.into()).map_err(|e| e.into())
         })?
     }
     /// Return the list of transactions made and received by the wallet. Note that this method only operate on the internal database, which first needs to be [Wallet.sync] manually.
     #[frb(sync)]
     pub fn list_transactions(
         &self,
-        include_raw: bool
+        include_raw: bool,
     ) -> Result<Vec<TransactionDetails>, BdkError> {
-        handle_mutex(&self.ptr, |wallet| {
+        execute_with_lock(&self.ptr, |wallet| {
             let mut transaction_details = vec![];
 
             // List transactions and convert them using try_into
@@ -139,7 +124,7 @@ impl BdkWallet {
     /// which first needs to be Wallet.sync manually.
     #[frb(sync)]
     pub fn list_unspent(&self) -> Result<Vec<LocalUtxo>, BdkError> {
-        handle_mutex(&self.ptr, |w| {
+        execute_with_lock(&self.ptr, |w| {
             let unspent: Vec<bdk::LocalUtxo> = w.list_unspent()?;
             Ok(unspent.into_iter().map(LocalUtxo::from).collect())
         })?
@@ -155,19 +140,25 @@ impl BdkWallet {
     pub fn sign(
         ptr: BdkWallet,
         psbt: BdkPsbt,
-        sign_options: Option<SignOptions>
+        sign_options: Option<SignOptions>,
     ) -> Result<bool, BdkError> {
-        let mut psbt = psbt.ptr.lock().map_err(|_| BdkError::Generic("Poison Error!".to_string()))?;
-        handle_mutex(&ptr.ptr, |w| {
-            w.sign(&mut psbt, sign_options.map(SignOptions::into).unwrap_or_default()).map_err(|e|
-                e.into()
+        let mut psbt = psbt
+            .ptr
+            .lock()
+            .map_err(|_| BdkError::Generic("Poison Error!".to_string()))?;
+        execute_with_lock(&ptr.ptr, |w| {
+            w.sign(
+                &mut psbt,
+                sign_options.map(SignOptions::into).unwrap_or_default(),
             )
+            .map_err(|e| e.into())
         })?
     }
     /// Sync the internal database with the blockchain.
     pub fn sync(ptr: BdkWallet, blockchain: &BdkBlockchain) -> Result<(), BdkError> {
-        handle_mutex(&ptr.ptr, |w| {
-            w.sync(blockchain.ptr.deref(), bdk::SyncOptions::default()).map_err(|e| e.into())
+        execute_with_lock(&ptr.ptr, |w| {
+            w.sync(blockchain.ptr.deref(), bdk::SyncOptions::default())
+                .map_err(|e| e.into())
         })?
     }
 
@@ -176,13 +167,13 @@ impl BdkWallet {
         &self,
         utxo: LocalUtxo,
         only_witness_utxo: bool,
-        sighash_type: Option<PsbtSigHashType>
+        sighash_type: Option<PsbtSigHashType>,
     ) -> anyhow::Result<Input, BdkError> {
-        handle_mutex(&self.ptr, |w| {
+        execute_with_lock(&self.ptr, |w| {
             let input = w.get_psbt_input(
                 utxo.try_into()?,
                 sighash_type.map(|e| e.into()),
-                only_witness_utxo
+                only_witness_utxo,
             )?;
             input.try_into()
         })?
@@ -191,16 +182,16 @@ impl BdkWallet {
     #[frb(sync)]
     pub fn get_descriptor_for_keychain(
         ptr: BdkWallet,
-        keychain: KeychainKind
+        keychain: KeychainKind,
     ) -> anyhow::Result<BdkDescriptor, BdkError> {
-        handle_mutex(&ptr.ptr, |w| {
+        execute_with_lock(&ptr.ptr, |w| {
             let extended_descriptor = w.get_descriptor_for_keychain(keychain.into());
             BdkDescriptor::new(extended_descriptor.to_string(), w.network().into())
         })?
     }
     #[frb(sync)]
-    pub fn policies(ptr: BdkWallet, keychain: KeychainKind) -> Result<Option<FfiPolicy>, BdkError> {
-        handle_mutex(&ptr.ptr, |w| {
+    pub fn policies(ptr: BdkWallet, keychain: KeychainKind) -> Result<Option<BdkPolicy>, BdkError> {
+        execute_with_lock(&ptr.ptr, |w| {
             w.policies(keychain.into())
                 .map_err(|e| e.into())
                 .map(|e| e.map(|f| f.into()))
@@ -214,10 +205,10 @@ pub fn finish_bump_fee_tx_builder(
     allow_shrinking: Option<BdkAddress>,
     wallet: BdkWallet,
     enable_rbf: bool,
-    n_sequence: Option<u32>
+    n_sequence: Option<u32>,
 ) -> anyhow::Result<(BdkPsbt, TransactionDetails), BdkError> {
     let txid = Txid::from_str(txid.as_str()).map_err(|e| BdkError::PsbtParse(e.to_string()))?;
-    handle_mutex(&wallet.ptr, |w| {
+    execute_with_lock(&wallet.ptr, |w| {
         let mut tx_builder = w.build_fee_bump(txid)?;
         tx_builder.fee_rate(bdk::FeeRate::from_sat_per_vb(fee_rate));
         if let Some(allow_shrinking) = &allow_shrinking {
@@ -251,11 +242,28 @@ pub fn tx_builder_finish(
     drain_wallet: bool,
     drain_to: Option<BdkScriptBuf>,
     rbf: Option<RbfValue>,
-    data: Vec<u8>
+    internal_policy_path: Option<HashMap<String, Vec<usize>>>,
+    external_policy_path: Option<HashMap<String, Vec<usize>>>,
+    data: Vec<u8>,
 ) -> anyhow::Result<(BdkPsbt, TransactionDetails), BdkError> {
-    handle_mutex(&wallet.ptr, |w| {
+    execute_with_lock(&wallet.ptr, |w| {
         let mut tx_builder = w.build_tx();
-
+        if let Some(path) = internal_policy_path {
+            tx_builder.policy_path(
+                path.into_iter()
+                    .map(|(key, value)| (key, value.into_iter().map(|x| x as usize).collect()))
+                    .collect::<BTreeMap<String, Vec<usize>>>(),
+                bdk::KeychainKind::Internal,
+            );
+        }
+        if let Some(path) = external_policy_path {
+            tx_builder.policy_path(
+                path.into_iter()
+                    .map(|(key, value)| (key, value.into_iter().map(|x| x as usize).collect()))
+                    .collect::<BTreeMap<String, Vec<usize>>>(),
+                bdk::KeychainKind::External,
+            );
+        }
         for e in recipients {
             tx_builder.add_recipient(e.script.into(), e.amount);
         }

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -15,6 +15,33 @@ flutter_rust_bridge::frb_generated_boilerplate_io!();
 
 // Section: dart2rust
 
+impl CstDecode<std::collections::HashMap<String, Vec<usize>>>
+    for *mut wire_cst_list_record_string_list_prim_usize_strict
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> std::collections::HashMap<String, Vec<usize>> {
+        let vec: Vec<(String, Vec<usize>)> = self.cst_decode();
+        vec.into_iter().collect()
+    }
+}
+impl CstDecode<std::collections::HashMap<Vec<u32>, Vec<crate::api::types::Condition>>>
+    for *mut wire_cst_list_record_list_prim_u_32_strict_list_condition
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> std::collections::HashMap<Vec<u32>, Vec<crate::api::types::Condition>> {
+        let vec: Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> = self.cst_decode();
+        vec.into_iter().collect()
+    }
+}
+impl CstDecode<std::collections::HashMap<u32, Vec<crate::api::types::Condition>>>
+    for *mut wire_cst_list_record_u_32_list_condition
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> std::collections::HashMap<u32, Vec<crate::api::types::Condition>> {
+        let vec: Vec<(u32, Vec<crate::api::types::Condition>)> = self.cst_decode();
+        vec.into_iter().collect()
+    }
+}
 impl CstDecode<RustOpaqueNom<bdk::bitcoin::Address>> for usize {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> RustOpaqueNom<bdk::bitcoin::Address> {
@@ -36,6 +63,12 @@ impl CstDecode<RustOpaqueNom<bdk::blockchain::AnyBlockchain>> for usize {
 impl CstDecode<RustOpaqueNom<bdk::descriptor::ExtendedDescriptor>> for usize {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> RustOpaqueNom<bdk::descriptor::ExtendedDescriptor> {
+        unsafe { decode_rust_opaque_nom(self as _) }
+    }
+}
+impl CstDecode<RustOpaqueNom<bdk::descriptor::Policy>> for usize {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> RustOpaqueNom<bdk::descriptor::Policy> {
         unsafe { decode_rust_opaque_nom(self as _) }
     }
 }
@@ -438,6 +471,14 @@ impl CstDecode<crate::api::key::BdkMnemonic> for wire_cst_bdk_mnemonic {
         }
     }
 }
+impl CstDecode<crate::api::types::BdkPolicy> for wire_cst_bdk_policy {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::BdkPolicy {
+        crate::api::types::BdkPolicy {
+            ptr: self.ptr.cst_decode(),
+        }
+    }
+}
 impl CstDecode<crate::api::psbt::BdkPsbt> for wire_cst_bdk_psbt {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::psbt::BdkPsbt {
@@ -572,6 +613,13 @@ impl CstDecode<crate::api::key::BdkMnemonic> for *mut wire_cst_bdk_mnemonic {
         CstDecode::<crate::api::key::BdkMnemonic>::cst_decode(*wrap).into()
     }
 }
+impl CstDecode<crate::api::types::BdkPolicy> for *mut wire_cst_bdk_policy {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::BdkPolicy {
+        let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+        CstDecode::<crate::api::types::BdkPolicy>::cst_decode(*wrap).into()
+    }
+}
 impl CstDecode<crate::api::psbt::BdkPsbt> for *mut wire_cst_bdk_psbt {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::psbt::BdkPsbt {
@@ -612,6 +660,19 @@ impl CstDecode<crate::api::blockchain::BlockchainConfig> for *mut wire_cst_block
     fn cst_decode(self) -> crate::api::blockchain::BlockchainConfig {
         let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
         CstDecode::<crate::api::blockchain::BlockchainConfig>::cst_decode(*wrap).into()
+    }
+}
+impl CstDecode<bool> for *mut bool {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> bool {
+        unsafe { *flutter_rust_bridge::for_generated::box_from_leak_ptr(self) }
+    }
+}
+impl CstDecode<crate::api::types::Condition> for *mut wire_cst_condition {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::Condition {
+        let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+        CstDecode::<crate::api::types::Condition>::cst_decode(*wrap).into()
     }
 }
 impl CstDecode<crate::api::error::ConsensusError> for *mut wire_cst_consensus_error {
@@ -688,6 +749,13 @@ impl CstDecode<crate::api::types::OutPoint> for *mut wire_cst_out_point {
     fn cst_decode(self) -> crate::api::types::OutPoint {
         let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
         CstDecode::<crate::api::types::OutPoint>::cst_decode(*wrap).into()
+    }
+}
+impl CstDecode<crate::api::types::PkOrF> for *mut wire_cst_pk_or_f {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::PkOrF {
+        let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+        CstDecode::<crate::api::types::PkOrF>::cst_decode(*wrap).into()
     }
 }
 impl CstDecode<crate::api::types::PsbtSigHashType> for *mut wire_cst_psbt_sig_hash_type {
@@ -767,6 +835,15 @@ impl CstDecode<u8> for *mut u8 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> u8 {
         unsafe { *flutter_rust_bridge::for_generated::box_from_leak_ptr(self) }
+    }
+}
+impl CstDecode<crate::api::types::Condition> for wire_cst_condition {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::Condition {
+        crate::api::types::Condition {
+            csv: self.csv.cst_decode(),
+            timelock: self.timelock.cst_decode(),
+        }
     }
 }
 impl CstDecode<crate::api::error::ConsensusError> for wire_cst_consensus_error {
@@ -935,6 +1012,26 @@ impl CstDecode<crate::api::types::Input> for wire_cst_input {
         }
     }
 }
+impl CstDecode<Vec<crate::api::types::BdkPolicy>> for *mut wire_cst_list_bdk_policy {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<crate::api::types::BdkPolicy> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
+    }
+}
+impl CstDecode<Vec<crate::api::types::Condition>> for *mut wire_cst_list_condition {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<crate::api::types::Condition> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
+    }
+}
 impl CstDecode<Vec<Vec<u8>>> for *mut wire_cst_list_list_prim_u_8_strict {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> Vec<Vec<u8>> {
@@ -965,6 +1062,34 @@ impl CstDecode<Vec<crate::api::types::OutPoint>> for *mut wire_cst_list_out_poin
         vec.into_iter().map(CstDecode::cst_decode).collect()
     }
 }
+impl CstDecode<Vec<crate::api::types::PkOrF>> for *mut wire_cst_list_pk_or_f {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<crate::api::types::PkOrF> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
+    }
+}
+impl CstDecode<Vec<u32>> for *mut wire_cst_list_prim_u_32_strict {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<u32> {
+        unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        }
+    }
+}
+impl CstDecode<Vec<u64>> for *mut wire_cst_list_prim_u_64_strict {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<u64> {
+        unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        }
+    }
+}
 impl CstDecode<Vec<u8>> for *mut wire_cst_list_prim_u_8_loose {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> Vec<u8> {
@@ -981,6 +1106,51 @@ impl CstDecode<Vec<u8>> for *mut wire_cst_list_prim_u_8_strict {
             let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
             flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
         }
+    }
+}
+impl CstDecode<Vec<usize>> for *mut wire_cst_list_prim_usize_strict {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<usize> {
+        unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        }
+    }
+}
+impl CstDecode<Vec<(Vec<u32>, Vec<crate::api::types::Condition>)>>
+    for *mut wire_cst_list_record_list_prim_u_32_strict_list_condition
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
+    }
+}
+impl CstDecode<Vec<(String, Vec<usize>)>>
+    for *mut wire_cst_list_record_string_list_prim_usize_strict
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<(String, Vec<usize>)> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
+    }
+}
+impl CstDecode<Vec<(u32, Vec<crate::api::types::Condition>)>>
+    for *mut wire_cst_list_record_u_32_list_condition
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> Vec<(u32, Vec<crate::api::types::Condition>)> {
+        let vec = unsafe {
+            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(CstDecode::cst_decode).collect()
     }
 }
 impl CstDecode<Vec<crate::api::types::ScriptAmount>> for *mut wire_cst_list_script_amount {
@@ -1088,6 +1258,32 @@ impl CstDecode<crate::api::types::Payload> for wire_cst_payload {
         }
     }
 }
+impl CstDecode<crate::api::types::PkOrF> for wire_cst_pk_or_f {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::PkOrF {
+        match self.tag {
+            0 => {
+                let ans = unsafe { self.kind.Pubkey };
+                crate::api::types::PkOrF::Pubkey {
+                    value: ans.value.cst_decode(),
+                }
+            }
+            1 => {
+                let ans = unsafe { self.kind.XOnlyPubkey };
+                crate::api::types::PkOrF::XOnlyPubkey {
+                    value: ans.value.cst_decode(),
+                }
+            }
+            2 => {
+                let ans = unsafe { self.kind.Fingerprint };
+                crate::api::types::PkOrF::Fingerprint {
+                    value: ans.value.cst_decode(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
 impl CstDecode<crate::api::types::PsbtSigHashType> for wire_cst_psbt_sig_hash_type {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::types::PsbtSigHashType {
@@ -1131,6 +1327,14 @@ impl
         (self.field0.cst_decode(), self.field1.cst_decode())
     }
 }
+impl CstDecode<(Vec<u32>, Vec<crate::api::types::Condition>)>
+    for wire_cst_record_list_prim_u_32_strict_list_condition
+{
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (Vec<u32>, Vec<crate::api::types::Condition>) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
 impl CstDecode<(crate::api::types::OutPoint, crate::api::types::Input, usize)>
     for wire_cst_record_out_point_input_usize
 {
@@ -1141,6 +1345,18 @@ impl CstDecode<(crate::api::types::OutPoint, crate::api::types::Input, usize)>
             self.field1.cst_decode(),
             self.field2.cst_decode(),
         )
+    }
+}
+impl CstDecode<(String, Vec<usize>)> for wire_cst_record_string_list_prim_usize_strict {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (String, Vec<usize>) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
+    }
+}
+impl CstDecode<(u32, Vec<crate::api::types::Condition>)> for wire_cst_record_u_32_list_condition {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> (u32, Vec<crate::api::types::Condition>) {
+        (self.field0.cst_decode(), self.field1.cst_decode())
     }
 }
 impl CstDecode<crate::api::blockchain::RpcConfig> for wire_cst_rpc_config {
@@ -1163,6 +1379,116 @@ impl CstDecode<crate::api::blockchain::RpcSyncParams> for wire_cst_rpc_sync_para
             start_time: self.start_time.cst_decode(),
             force_start_time: self.force_start_time.cst_decode(),
             poll_rate_sec: self.poll_rate_sec.cst_decode(),
+        }
+    }
+}
+impl CstDecode<crate::api::types::Satisfaction> for wire_cst_satisfaction {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::Satisfaction {
+        match self.tag {
+            0 => {
+                let ans = unsafe { self.kind.Partial };
+                crate::api::types::Satisfaction::Partial {
+                    n: ans.n.cst_decode(),
+                    m: ans.m.cst_decode(),
+                    items: ans.items.cst_decode(),
+                    sorted: ans.sorted.cst_decode(),
+                    conditions: ans.conditions.cst_decode(),
+                }
+            }
+            1 => {
+                let ans = unsafe { self.kind.PartialComplete };
+                crate::api::types::Satisfaction::PartialComplete {
+                    n: ans.n.cst_decode(),
+                    m: ans.m.cst_decode(),
+                    items: ans.items.cst_decode(),
+                    sorted: ans.sorted.cst_decode(),
+                    conditions: ans.conditions.cst_decode(),
+                }
+            }
+            2 => {
+                let ans = unsafe { self.kind.Complete };
+                crate::api::types::Satisfaction::Complete {
+                    condition: ans.condition.cst_decode(),
+                }
+            }
+            3 => {
+                let ans = unsafe { self.kind.None };
+                crate::api::types::Satisfaction::None {
+                    msg: ans.msg.cst_decode(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+impl CstDecode<crate::api::types::SatisfiableItem> for wire_cst_satisfiable_item {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::types::SatisfiableItem {
+        match self.tag {
+            0 => {
+                let ans = unsafe { self.kind.EcdsaSignature };
+                crate::api::types::SatisfiableItem::EcdsaSignature {
+                    key: ans.key.cst_decode(),
+                }
+            }
+            1 => {
+                let ans = unsafe { self.kind.SchnorrSignature };
+                crate::api::types::SatisfiableItem::SchnorrSignature {
+                    key: ans.key.cst_decode(),
+                }
+            }
+            2 => {
+                let ans = unsafe { self.kind.Sha256Preimage };
+                crate::api::types::SatisfiableItem::Sha256Preimage {
+                    hash: ans.hash.cst_decode(),
+                }
+            }
+            3 => {
+                let ans = unsafe { self.kind.Hash256Preimage };
+                crate::api::types::SatisfiableItem::Hash256Preimage {
+                    hash: ans.hash.cst_decode(),
+                }
+            }
+            4 => {
+                let ans = unsafe { self.kind.Ripemd160Preimage };
+                crate::api::types::SatisfiableItem::Ripemd160Preimage {
+                    hash: ans.hash.cst_decode(),
+                }
+            }
+            5 => {
+                let ans = unsafe { self.kind.Hash160Preimage };
+                crate::api::types::SatisfiableItem::Hash160Preimage {
+                    hash: ans.hash.cst_decode(),
+                }
+            }
+            6 => {
+                let ans = unsafe { self.kind.AbsoluteTimelock };
+                crate::api::types::SatisfiableItem::AbsoluteTimelock {
+                    value: ans.value.cst_decode(),
+                }
+            }
+            7 => {
+                let ans = unsafe { self.kind.RelativeTimelock };
+                crate::api::types::SatisfiableItem::RelativeTimelock {
+                    value: ans.value.cst_decode(),
+                }
+            }
+            8 => {
+                let ans = unsafe { self.kind.Multisig };
+                crate::api::types::SatisfiableItem::Multisig {
+                    keys: ans.keys.cst_decode(),
+                    threshold: ans.threshold.cst_decode(),
+                }
+            }
+            9 => {
+                let ans = unsafe { self.kind.Thresh };
+                crate::api::types::SatisfiableItem::Thresh {
+                    items: ans.items.cst_decode(),
+                    threshold: ans.threshold.cst_decode(),
+                }
+            }
+            _ => unreachable!(),
         }
     }
 }
@@ -1400,6 +1726,18 @@ impl Default for wire_cst_bdk_mnemonic {
         Self::new_with_null_ptr()
     }
 }
+impl NewWithNullPtr for wire_cst_bdk_policy {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            ptr: Default::default(),
+        }
+    }
+}
+impl Default for wire_cst_bdk_policy {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
 impl NewWithNullPtr for wire_cst_bdk_psbt {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1470,6 +1808,19 @@ impl NewWithNullPtr for wire_cst_blockchain_config {
     }
 }
 impl Default for wire_cst_blockchain_config {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_condition {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            csv: core::ptr::null_mut(),
+            timelock: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_condition {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1637,6 +1988,19 @@ impl Default for wire_cst_payload {
         Self::new_with_null_ptr()
     }
 }
+impl NewWithNullPtr for wire_cst_pk_or_f {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tag: -1,
+            kind: PkOrFKind { nil__: () },
+        }
+    }
+}
+impl Default for wire_cst_pk_or_f {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
 impl NewWithNullPtr for wire_cst_psbt_sig_hash_type {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1688,6 +2052,19 @@ impl Default for wire_cst_record_bdk_psbt_transaction_details {
         Self::new_with_null_ptr()
     }
 }
+impl NewWithNullPtr for wire_cst_record_list_prim_u_32_strict_list_condition {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: core::ptr::null_mut(),
+            field1: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_record_list_prim_u_32_strict_list_condition {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
 impl NewWithNullPtr for wire_cst_record_out_point_input_usize {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1698,6 +2075,32 @@ impl NewWithNullPtr for wire_cst_record_out_point_input_usize {
     }
 }
 impl Default for wire_cst_record_out_point_input_usize {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_record_string_list_prim_usize_strict {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: core::ptr::null_mut(),
+            field1: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_record_string_list_prim_usize_strict {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_record_u_32_list_condition {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            field0: Default::default(),
+            field1: core::ptr::null_mut(),
+        }
+    }
+}
+impl Default for wire_cst_record_u_32_list_condition {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1729,6 +2132,32 @@ impl NewWithNullPtr for wire_cst_rpc_sync_params {
     }
 }
 impl Default for wire_cst_rpc_sync_params {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_satisfaction {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tag: -1,
+            kind: SatisfactionKind { nil__: () },
+        }
+    }
+}
+impl Default for wire_cst_satisfaction {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+impl NewWithNullPtr for wire_cst_satisfiable_item {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tag: -1,
+            kind: SatisfiableItemKind { nil__: () },
+        }
+    }
+}
+impl Default for wire_cst_satisfiable_item {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -2300,6 +2729,48 @@ pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_address_to_qr_
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_as_string(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_as_string_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_contribution(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_contribution_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_id(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_id_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_item(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_item_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_requires_path(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_requires_path_impl(that)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_policy_satisfaction(
+    that: *mut wire_cst_bdk_policy,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__types__bdk_policy_satisfaction_impl(that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__types__bdk_script_buf_as_string(
     that: *mut wire_cst_bdk_script_buf,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
@@ -2539,6 +3010,14 @@ pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_new(
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_policies(
+    ptr: *mut wire_cst_bdk_wallet,
+    keychain: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__api__wallet__bdk_wallet_policies_impl(ptr, keychain)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__bdk_wallet_sign(
     port_: i64,
     ptr: *mut wire_cst_bdk_wallet,
@@ -2593,6 +3072,8 @@ pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish
     drain_wallet: bool,
     drain_to: *mut wire_cst_bdk_script_buf,
     rbf: *mut wire_cst_rbf_value,
+    internal_policy_path: *mut wire_cst_list_record_string_list_prim_usize_strict,
+    external_policy_path: *mut wire_cst_list_record_string_list_prim_usize_strict,
     data: *mut wire_cst_list_prim_u_8_loose,
 ) {
     wire__crate__api__wallet__tx_builder_finish_impl(
@@ -2609,6 +3090,8 @@ pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish
         drain_wallet,
         drain_to,
         rbf,
+        internal_policy_path,
+        external_policy_path,
         data,
     )
 }
@@ -2682,6 +3165,24 @@ pub extern "C" fn frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_
 ) {
     unsafe {
         StdArc::<bdk::descriptor::ExtendedDescriptor>::decrement_strong_count(ptr as _);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_rust_arc_increment_strong_count_RustOpaque_bdkdescriptorPolicy(
+    ptr: *const std::ffi::c_void,
+) {
+    unsafe {
+        StdArc::<bdk::descriptor::Policy>::increment_strong_count(ptr as _);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_rust_arc_decrement_strong_count_RustOpaque_bdkdescriptorPolicy(
+    ptr: *const std::ffi::c_void,
+) {
+    unsafe {
+        StdArc::<bdk::descriptor::Policy>::decrement_strong_count(ptr as _);
     }
 }
 
@@ -2862,6 +3363,11 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_bdk_mnemonic() -> *mut 
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_bdk_policy() -> *mut wire_cst_bdk_policy {
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_bdk_policy::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_bdk_psbt() -> *mut wire_cst_bdk_psbt {
     flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_bdk_psbt::new_with_null_ptr())
 }
@@ -2898,6 +3404,16 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_blockchain_config(
     flutter_rust_bridge::for_generated::new_leak_box_ptr(
         wire_cst_blockchain_config::new_with_null_ptr(),
     )
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_bool(value: bool) -> *mut bool {
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(value)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_condition() -> *mut wire_cst_condition {
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_condition::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -2968,6 +3484,11 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_lock_time() -> *mut wir
 #[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_out_point() -> *mut wire_cst_out_point {
     flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_out_point::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_pk_or_f() -> *mut wire_cst_pk_or_f {
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_pk_or_f::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -3042,6 +3563,34 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_box_autoadd_u_8(value: u8) -> *mut 
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_bdk_policy(
+    len: i32,
+) -> *mut wire_cst_list_bdk_policy {
+    let wrap = wire_cst_list_bdk_policy {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_bdk_policy>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_condition(
+    len: i32,
+) -> *mut wire_cst_list_condition {
+    let wrap = wire_cst_list_condition {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_condition>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_cst_new_list_list_prim_u_8_strict(
     len: i32,
 ) -> *mut wire_cst_list_list_prim_u_8_strict {
@@ -3084,6 +3633,40 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_list_out_point(
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_pk_or_f(len: i32) -> *mut wire_cst_list_pk_or_f {
+    let wrap = wire_cst_list_pk_or_f {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_pk_or_f>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_u_32_strict(
+    len: i32,
+) -> *mut wire_cst_list_prim_u_32_strict {
+    let ans = wire_cst_list_prim_u_32_strict {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_u_64_strict(
+    len: i32,
+) -> *mut wire_cst_list_prim_u_64_strict {
+    let ans = wire_cst_list_prim_u_64_strict {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_u_8_loose(
     len: i32,
 ) -> *mut wire_cst_list_prim_u_8_loose {
@@ -3103,6 +3686,59 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(
         len,
     };
     flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_usize_strict(
+    len: i32,
+) -> *mut wire_cst_list_prim_usize_strict {
+    let ans = wire_cst_list_prim_usize_strict {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(
+    len: i32,
+) -> *mut wire_cst_list_record_list_prim_u_32_strict_list_condition {
+    let wrap = wire_cst_list_record_list_prim_u_32_strict_list_condition {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_record_list_prim_u_32_strict_list_condition>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(
+    len: i32,
+) -> *mut wire_cst_list_record_string_list_prim_usize_strict {
+    let wrap = wire_cst_list_record_string_list_prim_usize_strict {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_record_string_list_prim_usize_strict>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_u_32_list_condition(
+    len: i32,
+) -> *mut wire_cst_list_record_u_32_list_condition {
+    let wrap = wire_cst_list_record_u_32_list_condition {
+        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+            <wire_cst_record_u_32_list_condition>::new_with_null_ptr(),
+            len,
+        ),
+        len,
+    };
+    flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
 }
 
 #[no_mangle]
@@ -3550,6 +4186,11 @@ pub struct wire_cst_bdk_mnemonic {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_bdk_policy {
+    ptr: usize,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_bdk_psbt {
     ptr: usize,
 }
@@ -3602,6 +4243,12 @@ pub struct wire_cst_BlockchainConfig_Esplora {
 #[derive(Clone, Copy)]
 pub struct wire_cst_BlockchainConfig_Rpc {
     config: *mut wire_cst_rpc_config,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_condition {
+    csv: *mut u32,
+    timelock: *mut wire_cst_lock_time,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3789,6 +4436,18 @@ pub struct wire_cst_input {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_list_bdk_policy {
+    ptr: *mut wire_cst_bdk_policy,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_condition {
+    ptr: *mut wire_cst_condition,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_list_prim_u_8_strict {
     ptr: *mut *mut wire_cst_list_prim_u_8_strict,
     len: i32,
@@ -3807,6 +4466,24 @@ pub struct wire_cst_list_out_point {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_list_pk_or_f {
+    ptr: *mut wire_cst_pk_or_f,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_prim_u_32_strict {
+    ptr: *mut u32,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_prim_u_64_strict {
+    ptr: *mut u64,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8_loose {
     ptr: *mut u8,
     len: i32,
@@ -3815,6 +4492,30 @@ pub struct wire_cst_list_prim_u_8_loose {
 #[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8_strict {
     ptr: *mut u8,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_prim_usize_strict {
+    ptr: *mut usize,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_record_list_prim_u_32_strict_list_condition {
+    ptr: *mut wire_cst_record_list_prim_u_32_strict_list_condition,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_record_string_list_prim_usize_strict {
+    ptr: *mut wire_cst_record_string_list_prim_usize_strict,
+    len: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_list_record_u_32_list_condition {
+    ptr: *mut wire_cst_record_u_32_list_condition,
     len: i32,
 }
 #[repr(C)]
@@ -3910,6 +4611,35 @@ pub struct wire_cst_Payload_WitnessProgram {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_pk_or_f {
+    tag: i32,
+    kind: PkOrFKind,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union PkOrFKind {
+    Pubkey: wire_cst_PkOrF_Pubkey,
+    XOnlyPubkey: wire_cst_PkOrF_XOnlyPubkey,
+    Fingerprint: wire_cst_PkOrF_Fingerprint,
+    nil__: (),
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_PkOrF_Pubkey {
+    value: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_PkOrF_XOnlyPubkey {
+    value: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_PkOrF_Fingerprint {
+    value: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_psbt_sig_hash_type {
     inner: u32,
 }
@@ -3944,10 +4674,28 @@ pub struct wire_cst_record_bdk_psbt_transaction_details {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct wire_cst_record_list_prim_u_32_strict_list_condition {
+    field0: *mut wire_cst_list_prim_u_32_strict,
+    field1: *mut wire_cst_list_condition,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_record_out_point_input_usize {
     field0: wire_cst_out_point,
     field1: wire_cst_input,
     field2: usize,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_record_string_list_prim_usize_strict {
+    field0: *mut wire_cst_list_prim_u_8_strict,
+    field1: *mut wire_cst_list_prim_usize_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_record_u_32_list_condition {
+    field0: u32,
+    field1: *mut wire_cst_list_condition,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3965,6 +4713,122 @@ pub struct wire_cst_rpc_sync_params {
     start_time: u64,
     force_start_time: bool,
     poll_rate_sec: u64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_satisfaction {
+    tag: i32,
+    kind: SatisfactionKind,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union SatisfactionKind {
+    Partial: wire_cst_Satisfaction_Partial,
+    PartialComplete: wire_cst_Satisfaction_PartialComplete,
+    Complete: wire_cst_Satisfaction_Complete,
+    None: wire_cst_Satisfaction_None,
+    nil__: (),
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_Satisfaction_Partial {
+    n: u64,
+    m: u64,
+    items: *mut wire_cst_list_prim_u_64_strict,
+    sorted: *mut bool,
+    conditions: *mut wire_cst_list_record_u_32_list_condition,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_Satisfaction_PartialComplete {
+    n: u64,
+    m: u64,
+    items: *mut wire_cst_list_prim_u_64_strict,
+    sorted: *mut bool,
+    conditions: *mut wire_cst_list_record_list_prim_u_32_strict_list_condition,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_Satisfaction_Complete {
+    condition: *mut wire_cst_condition,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_Satisfaction_None {
+    msg: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_satisfiable_item {
+    tag: i32,
+    kind: SatisfiableItemKind,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union SatisfiableItemKind {
+    EcdsaSignature: wire_cst_SatisfiableItem_EcdsaSignature,
+    SchnorrSignature: wire_cst_SatisfiableItem_SchnorrSignature,
+    Sha256Preimage: wire_cst_SatisfiableItem_Sha256Preimage,
+    Hash256Preimage: wire_cst_SatisfiableItem_Hash256Preimage,
+    Ripemd160Preimage: wire_cst_SatisfiableItem_Ripemd160Preimage,
+    Hash160Preimage: wire_cst_SatisfiableItem_Hash160Preimage,
+    AbsoluteTimelock: wire_cst_SatisfiableItem_AbsoluteTimelock,
+    RelativeTimelock: wire_cst_SatisfiableItem_RelativeTimelock,
+    Multisig: wire_cst_SatisfiableItem_Multisig,
+    Thresh: wire_cst_SatisfiableItem_Thresh,
+    nil__: (),
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_EcdsaSignature {
+    key: *mut wire_cst_pk_or_f,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_SchnorrSignature {
+    key: *mut wire_cst_pk_or_f,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Sha256Preimage {
+    hash: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Hash256Preimage {
+    hash: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Ripemd160Preimage {
+    hash: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Hash160Preimage {
+    hash: *mut wire_cst_list_prim_u_8_strict,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_AbsoluteTimelock {
+    value: *mut wire_cst_lock_time,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_RelativeTimelock {
+    value: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Multisig {
+    keys: *mut wire_cst_list_pk_or_f,
+    threshold: u64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct wire_cst_SatisfiableItem_Thresh {
+    items: *mut wire_cst_list_bdk_policy,
+    threshold: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -15,12 +15,12 @@ flutter_rust_bridge::frb_generated_boilerplate_io!();
 
 // Section: dart2rust
 
-impl CstDecode<std::collections::HashMap<String, Vec<usize>>>
-    for *mut wire_cst_list_record_string_list_prim_usize_strict
+impl CstDecode<std::collections::HashMap<String, Vec<u32>>>
+    for *mut wire_cst_list_record_string_list_prim_u_32_strict
 {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> std::collections::HashMap<String, Vec<usize>> {
-        let vec: Vec<(String, Vec<usize>)> = self.cst_decode();
+    fn cst_decode(self) -> std::collections::HashMap<String, Vec<u32>> {
+        let vec: Vec<(String, Vec<u32>)> = self.cst_decode();
         vec.into_iter().collect()
     }
 }
@@ -1108,15 +1108,6 @@ impl CstDecode<Vec<u8>> for *mut wire_cst_list_prim_u_8_strict {
         }
     }
 }
-impl CstDecode<Vec<usize>> for *mut wire_cst_list_prim_usize_strict {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> Vec<usize> {
-        unsafe {
-            let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
-            flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
-        }
-    }
-}
 impl CstDecode<Vec<(Vec<u32>, Vec<crate::api::types::Condition>)>>
     for *mut wire_cst_list_record_list_prim_u_32_strict_list_condition
 {
@@ -1129,11 +1120,9 @@ impl CstDecode<Vec<(Vec<u32>, Vec<crate::api::types::Condition>)>>
         vec.into_iter().map(CstDecode::cst_decode).collect()
     }
 }
-impl CstDecode<Vec<(String, Vec<usize>)>>
-    for *mut wire_cst_list_record_string_list_prim_usize_strict
-{
+impl CstDecode<Vec<(String, Vec<u32>)>> for *mut wire_cst_list_record_string_list_prim_u_32_strict {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> Vec<(String, Vec<usize>)> {
+    fn cst_decode(self) -> Vec<(String, Vec<u32>)> {
         let vec = unsafe {
             let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
             flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
@@ -1347,9 +1336,9 @@ impl CstDecode<(crate::api::types::OutPoint, crate::api::types::Input, usize)>
         )
     }
 }
-impl CstDecode<(String, Vec<usize>)> for wire_cst_record_string_list_prim_usize_strict {
+impl CstDecode<(String, Vec<u32>)> for wire_cst_record_string_list_prim_u_32_strict {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> (String, Vec<usize>) {
+    fn cst_decode(self) -> (String, Vec<u32>) {
         (self.field0.cst_decode(), self.field1.cst_decode())
     }
 }
@@ -2079,7 +2068,7 @@ impl Default for wire_cst_record_out_point_input_usize {
         Self::new_with_null_ptr()
     }
 }
-impl NewWithNullPtr for wire_cst_record_string_list_prim_usize_strict {
+impl NewWithNullPtr for wire_cst_record_string_list_prim_u_32_strict {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: core::ptr::null_mut(),
@@ -2087,7 +2076,7 @@ impl NewWithNullPtr for wire_cst_record_string_list_prim_usize_strict {
         }
     }
 }
-impl Default for wire_cst_record_string_list_prim_usize_strict {
+impl Default for wire_cst_record_string_list_prim_u_32_strict {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -3072,8 +3061,8 @@ pub extern "C" fn frbgen_bdk_flutter_wire__crate__api__wallet__tx_builder_finish
     drain_wallet: bool,
     drain_to: *mut wire_cst_bdk_script_buf,
     rbf: *mut wire_cst_rbf_value,
-    internal_policy_path: *mut wire_cst_list_record_string_list_prim_usize_strict,
-    external_policy_path: *mut wire_cst_list_record_string_list_prim_usize_strict,
+    internal_policy_path: *mut wire_cst_list_record_string_list_prim_u_32_strict,
+    external_policy_path: *mut wire_cst_list_record_string_list_prim_u_32_strict,
     data: *mut wire_cst_list_prim_u_8_loose,
 ) {
     wire__crate__api__wallet__tx_builder_finish_impl(
@@ -3689,17 +3678,6 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_u_8_strict(
 }
 
 #[no_mangle]
-pub extern "C" fn frbgen_bdk_flutter_cst_new_list_prim_usize_strict(
-    len: i32,
-) -> *mut wire_cst_list_prim_usize_strict {
-    let ans = wire_cst_list_prim_usize_strict {
-        ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
-        len,
-    };
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
-}
-
-#[no_mangle]
 pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_list_condition(
     len: i32,
 ) -> *mut wire_cst_list_record_list_prim_u_32_strict_list_condition {
@@ -3714,12 +3692,12 @@ pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_list_prim_u_32_strict_l
 }
 
 #[no_mangle]
-pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_string_list_prim_usize_strict(
+pub extern "C" fn frbgen_bdk_flutter_cst_new_list_record_string_list_prim_u_32_strict(
     len: i32,
-) -> *mut wire_cst_list_record_string_list_prim_usize_strict {
-    let wrap = wire_cst_list_record_string_list_prim_usize_strict {
+) -> *mut wire_cst_list_record_string_list_prim_u_32_strict {
+    let wrap = wire_cst_list_record_string_list_prim_u_32_strict {
         ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
-            <wire_cst_record_string_list_prim_usize_strict>::new_with_null_ptr(),
+            <wire_cst_record_string_list_prim_u_32_strict>::new_with_null_ptr(),
             len,
         ),
         len,
@@ -4496,20 +4474,14 @@ pub struct wire_cst_list_prim_u_8_strict {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_list_prim_usize_strict {
-    ptr: *mut usize,
-    len: i32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
 pub struct wire_cst_list_record_list_prim_u_32_strict_list_condition {
     ptr: *mut wire_cst_record_list_prim_u_32_strict_list_condition,
     len: i32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_list_record_string_list_prim_usize_strict {
-    ptr: *mut wire_cst_record_string_list_prim_usize_strict,
+pub struct wire_cst_list_record_string_list_prim_u_32_strict {
+    ptr: *mut wire_cst_record_string_list_prim_u_32_strict,
     len: i32,
 }
 #[repr(C)]
@@ -4687,9 +4659,9 @@ pub struct wire_cst_record_out_point_input_usize {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct wire_cst_record_string_list_prim_usize_strict {
+pub struct wire_cst_record_string_list_prim_u_32_strict {
     field0: *mut wire_cst_list_prim_u_8_strict,
-    field1: *mut wire_cst_list_prim_usize_strict,
+    field1: *mut wire_cst_list_prim_u_32_strict,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2038,8 +2038,8 @@ fn wire__crate__api__wallet__tx_builder_finish_impl(
     drain_wallet: impl CstDecode<bool>,
     drain_to: impl CstDecode<Option<crate::api::types::BdkScriptBuf>>,
     rbf: impl CstDecode<Option<crate::api::types::RbfValue>>,
-    internal_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<usize>>>>,
-    external_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<usize>>>>,
+    internal_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<u32>>>>,
+    external_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<u32>>>>,
     data: impl CstDecode<Vec<u8>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -2213,10 +2213,10 @@ impl CstDecode<crate::api::types::WordCount> for i32 {
         }
     }
 }
-impl SseDecode for std::collections::HashMap<String, Vec<usize>> {
+impl SseDecode for std::collections::HashMap<String, Vec<u32>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <Vec<(String, Vec<usize>)>>::sse_decode(deserializer);
+        let mut inner = <Vec<(String, Vec<u32>)>>::sse_decode(deserializer);
         return inner.into_iter().collect();
     }
 }
@@ -3195,18 +3195,6 @@ impl SseDecode for Vec<u8> {
     }
 }
 
-impl SseDecode for Vec<usize> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut len_ = <i32>::sse_decode(deserializer);
-        let mut ans_ = vec![];
-        for idx_ in 0..len_ {
-            ans_.push(<usize>::sse_decode(deserializer));
-        }
-        return ans_;
-    }
-}
-
 impl SseDecode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3221,13 +3209,13 @@ impl SseDecode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
     }
 }
 
-impl SseDecode for Vec<(String, Vec<usize>)> {
+impl SseDecode for Vec<(String, Vec<u32>)> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut len_ = <i32>::sse_decode(deserializer);
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
-            ans_.push(<(String, Vec<usize>)>::sse_decode(deserializer));
+            ans_.push(<(String, Vec<u32>)>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -3347,11 +3335,11 @@ impl SseDecode for crate::api::types::Network {
     }
 }
 
-impl SseDecode for Option<std::collections::HashMap<String, Vec<usize>>> {
+impl SseDecode for Option<std::collections::HashMap<String, Vec<u32>>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
-            return Some(<std::collections::HashMap<String, Vec<usize>>>::sse_decode(
+            return Some(<std::collections::HashMap<String, Vec<u32>>>::sse_decode(
                 deserializer,
             ));
         } else {
@@ -3718,11 +3706,11 @@ impl SseDecode for (crate::api::types::OutPoint, crate::api::types::Input, usize
     }
 }
 
-impl SseDecode for (String, Vec<usize>) {
+impl SseDecode for (String, Vec<u32>) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <String>::sse_decode(deserializer);
-        let mut var_field1 = <Vec<usize>>::sse_decode(deserializer);
+        let mut var_field1 = <Vec<u32>>::sse_decode(deserializer);
         return (var_field0, var_field1);
     }
 }
@@ -5474,10 +5462,10 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::WordCount>
     }
 }
 
-impl SseEncode for std::collections::HashMap<String, Vec<usize>> {
+impl SseEncode for std::collections::HashMap<String, Vec<u32>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <Vec<(String, Vec<usize>)>>::sse_encode(self.into_iter().collect(), serializer);
+        <Vec<(String, Vec<u32>)>>::sse_encode(self.into_iter().collect(), serializer);
     }
 }
 
@@ -6374,16 +6362,6 @@ impl SseEncode for Vec<u8> {
     }
 }
 
-impl SseEncode for Vec<usize> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i32>::sse_encode(self.len() as _, serializer);
-        for item in self {
-            <usize>::sse_encode(item, serializer);
-        }
-    }
-}
-
 impl SseEncode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6394,12 +6372,12 @@ impl SseEncode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
     }
 }
 
-impl SseEncode for Vec<(String, Vec<usize>)> {
+impl SseEncode for Vec<(String, Vec<u32>)> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
-            <(String, Vec<usize>)>::sse_encode(item, serializer);
+            <(String, Vec<u32>)>::sse_encode(item, serializer);
         }
     }
 }
@@ -6501,12 +6479,12 @@ impl SseEncode for crate::api::types::Network {
     }
 }
 
-impl SseEncode for Option<std::collections::HashMap<String, Vec<usize>>> {
+impl SseEncode for Option<std::collections::HashMap<String, Vec<u32>>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
-            <std::collections::HashMap<String, Vec<usize>>>::sse_encode(value, serializer);
+            <std::collections::HashMap<String, Vec<u32>>>::sse_encode(value, serializer);
         }
     }
 }
@@ -6821,11 +6799,11 @@ impl SseEncode for (crate::api::types::OutPoint, crate::api::types::Input, usize
     }
 }
 
-impl SseEncode for (String, Vec<usize>) {
+impl SseEncode for (String, Vec<u32>) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.0, serializer);
-        <Vec<usize>>::sse_encode(self.1, serializer);
+        <Vec<u32>>::sse_encode(self.1, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1897842111;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -321771070;
 
 // Section: executor
 
@@ -1193,6 +1193,117 @@ fn wire__crate__api__types__bdk_address_to_qr_uri_impl(
         },
     )
 }
+fn wire__crate__api__types__bdk_policy_as_string_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_as_string",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, crate::api::error::BdkError>((move || {
+                let output_ok = crate::api::types::BdkPolicy::as_string(&api_that)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__types__bdk_policy_contribution_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_contribution",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::types::BdkPolicy::contribution(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__types__bdk_policy_id_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_id",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::types::BdkPolicy::id(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__types__bdk_policy_item_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_item",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::types::BdkPolicy::item(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__types__bdk_policy_requires_path_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_requires_path",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::types::BdkPolicy::requires_path(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__types__bdk_policy_satisfaction_impl(
+    that: impl CstDecode<crate::api::types::BdkPolicy>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_policy_satisfaction",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::types::BdkPolicy::satisfaction(&api_that))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__types__bdk_script_buf_as_string_impl(
     that: impl CstDecode<crate::api::types::BdkScriptBuf>,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
@@ -1806,6 +1917,26 @@ fn wire__crate__api__wallet__bdk_wallet_new_impl(
         },
     )
 }
+fn wire__crate__api__wallet__bdk_wallet_policies_impl(
+    ptr: impl CstDecode<crate::api::wallet::BdkWallet>,
+    keychain: impl CstDecode<crate::api::types::KeychainKind>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bdk_wallet_policies",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let api_ptr = ptr.cst_decode();
+            let api_keychain = keychain.cst_decode();
+            transform_result_dco::<_, _, crate::api::error::BdkError>((move || {
+                let output_ok = crate::api::wallet::BdkWallet::policies(api_ptr, api_keychain)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__wallet__bdk_wallet_sign_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr: impl CstDecode<crate::api::wallet::BdkWallet>,
@@ -1907,6 +2038,8 @@ fn wire__crate__api__wallet__tx_builder_finish_impl(
     drain_wallet: impl CstDecode<bool>,
     drain_to: impl CstDecode<Option<crate::api::types::BdkScriptBuf>>,
     rbf: impl CstDecode<Option<crate::api::types::RbfValue>>,
+    internal_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<usize>>>>,
+    external_policy_path: impl CstDecode<Option<std::collections::HashMap<String, Vec<usize>>>>,
     data: impl CstDecode<Vec<u8>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
@@ -1928,6 +2061,8 @@ fn wire__crate__api__wallet__tx_builder_finish_impl(
             let api_drain_wallet = drain_wallet.cst_decode();
             let api_drain_to = drain_to.cst_decode();
             let api_rbf = rbf.cst_decode();
+            let api_internal_policy_path = internal_policy_path.cst_decode();
+            let api_external_policy_path = external_policy_path.cst_decode();
             let api_data = data.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::api::error::BdkError>((move || {
@@ -1944,6 +2079,8 @@ fn wire__crate__api__wallet__tx_builder_finish_impl(
                         api_drain_wallet,
                         api_drain_to,
                         api_rbf,
+                        api_internal_policy_path,
+                        api_external_policy_path,
                         api_data,
                     )?;
                     Ok(output_ok)
@@ -2076,6 +2213,31 @@ impl CstDecode<crate::api::types::WordCount> for i32 {
         }
     }
 }
+impl SseDecode for std::collections::HashMap<String, Vec<usize>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <Vec<(String, Vec<usize>)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
+    }
+}
+
+impl SseDecode for std::collections::HashMap<Vec<u32>, Vec<crate::api::types::Condition>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner =
+            <Vec<(Vec<u32>, Vec<crate::api::types::Condition>)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
+    }
+}
+
+impl SseDecode for std::collections::HashMap<u32, Vec<crate::api::types::Condition>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <Vec<(u32, Vec<crate::api::types::Condition>)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
+    }
+}
+
 impl SseDecode for RustOpaqueNom<bdk::bitcoin::Address> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2101,6 +2263,14 @@ impl SseDecode for RustOpaqueNom<bdk::blockchain::AnyBlockchain> {
 }
 
 impl SseDecode for RustOpaqueNom<bdk::descriptor::ExtendedDescriptor> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return unsafe { decode_rust_opaque_nom(inner) };
+    }
+}
+
+impl SseDecode for RustOpaqueNom<bdk::descriptor::Policy> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <usize>::sse_decode(deserializer);
@@ -2571,6 +2741,14 @@ impl SseDecode for crate::api::key::BdkMnemonic {
     }
 }
 
+impl SseDecode for crate::api::types::BdkPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_ptr = <RustOpaqueNom<bdk::descriptor::Policy>>::sse_decode(deserializer);
+        return crate::api::types::BdkPolicy { ptr: var_ptr };
+    }
+}
+
 impl SseDecode for crate::api::psbt::BdkPsbt {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2662,6 +2840,18 @@ impl SseDecode for crate::api::types::ChangeSpendPolicy {
             1 => crate::api::types::ChangeSpendPolicy::OnlyChange,
             2 => crate::api::types::ChangeSpendPolicy::ChangeForbidden,
             _ => unreachable!("Invalid variant for ChangeSpendPolicy: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::types::Condition {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_csv = <Option<u32>>::sse_decode(deserializer);
+        let mut var_timelock = <Option<crate::api::types::LockTime>>::sse_decode(deserializer);
+        return crate::api::types::Condition {
+            csv: var_csv,
+            timelock: var_timelock,
         };
     }
 }
@@ -2897,6 +3087,30 @@ impl SseDecode for crate::api::types::KeychainKind {
     }
 }
 
+impl SseDecode for Vec<crate::api::types::BdkPolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::types::BdkPolicy>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::types::Condition> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::types::Condition>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<Vec<u8>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2933,6 +3147,42 @@ impl SseDecode for Vec<crate::api::types::OutPoint> {
     }
 }
 
+impl SseDecode for Vec<crate::api::types::PkOrF> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::types::PkOrF>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<u32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<u32>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<u64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<u64>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2940,6 +3190,58 @@ impl SseDecode for Vec<u8> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<u8>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<usize> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<usize>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<(Vec<u32>, Vec<crate::api::types::Condition>)>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<(String, Vec<usize>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<(String, Vec<usize>)>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<(u32, Vec<crate::api::types::Condition>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<(u32, Vec<crate::api::types::Condition>)>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -3045,6 +3347,19 @@ impl SseDecode for crate::api::types::Network {
     }
 }
 
+impl SseDecode for Option<std::collections::HashMap<String, Vec<usize>>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<std::collections::HashMap<String, Vec<usize>>>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3074,6 +3389,17 @@ impl SseDecode for Option<crate::api::descriptor::BdkDescriptor> {
             return Some(<crate::api::descriptor::BdkDescriptor>::sse_decode(
                 deserializer,
             ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::types::BdkPolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::types::BdkPolicy>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -3115,6 +3441,17 @@ impl SseDecode for Option<crate::api::types::BlockTime> {
     }
 }
 
+impl SseDecode for Option<bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<bool>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<f32> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3131,6 +3468,17 @@ impl SseDecode for Option<crate::api::types::FeeRate> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::api::types::FeeRate>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::types::LockTime> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::types::LockTime>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -3277,6 +3625,30 @@ impl SseDecode for crate::api::types::Payload {
     }
 }
 
+impl SseDecode for crate::api::types::PkOrF {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_value = <String>::sse_decode(deserializer);
+                return crate::api::types::PkOrF::Pubkey { value: var_value };
+            }
+            1 => {
+                let mut var_value = <String>::sse_decode(deserializer);
+                return crate::api::types::PkOrF::XOnlyPubkey { value: var_value };
+            }
+            2 => {
+                let mut var_value = <String>::sse_decode(deserializer);
+                return crate::api::types::PkOrF::Fingerprint { value: var_value };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::api::types::PsbtSigHashType {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3327,6 +3699,15 @@ impl SseDecode
     }
 }
 
+impl SseDecode for (Vec<u32>, Vec<crate::api::types::Condition>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_field1 = <Vec<crate::api::types::Condition>>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
 impl SseDecode for (crate::api::types::OutPoint, crate::api::types::Input, usize) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3334,6 +3715,24 @@ impl SseDecode for (crate::api::types::OutPoint, crate::api::types::Input, usize
         let mut var_field1 = <crate::api::types::Input>::sse_decode(deserializer);
         let mut var_field2 = <usize>::sse_decode(deserializer);
         return (var_field0, var_field1, var_field2);
+    }
+}
+
+impl SseDecode for (String, Vec<usize>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <Vec<usize>>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (u32, Vec<crate::api::types::Condition>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <u32>::sse_decode(deserializer);
+        let mut var_field1 = <Vec<crate::api::types::Condition>>::sse_decode(deserializer);
+        return (var_field0, var_field1);
     }
 }
 
@@ -3369,6 +3768,122 @@ impl SseDecode for crate::api::blockchain::RpcSyncParams {
             force_start_time: var_forceStartTime,
             poll_rate_sec: var_pollRateSec,
         };
+    }
+}
+
+impl SseDecode for crate::api::types::Satisfaction {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_n = <u64>::sse_decode(deserializer);
+                let mut var_m = <u64>::sse_decode(deserializer);
+                let mut var_items = <Vec<u64>>::sse_decode(deserializer);
+                let mut var_sorted = <Option<bool>>::sse_decode(deserializer);
+                let mut var_conditions = <std::collections::HashMap<
+                    u32,
+                    Vec<crate::api::types::Condition>,
+                >>::sse_decode(deserializer);
+                return crate::api::types::Satisfaction::Partial {
+                    n: var_n,
+                    m: var_m,
+                    items: var_items,
+                    sorted: var_sorted,
+                    conditions: var_conditions,
+                };
+            }
+            1 => {
+                let mut var_n = <u64>::sse_decode(deserializer);
+                let mut var_m = <u64>::sse_decode(deserializer);
+                let mut var_items = <Vec<u64>>::sse_decode(deserializer);
+                let mut var_sorted = <Option<bool>>::sse_decode(deserializer);
+                let mut var_conditions = <std::collections::HashMap<
+                    Vec<u32>,
+                    Vec<crate::api::types::Condition>,
+                >>::sse_decode(deserializer);
+                return crate::api::types::Satisfaction::PartialComplete {
+                    n: var_n,
+                    m: var_m,
+                    items: var_items,
+                    sorted: var_sorted,
+                    conditions: var_conditions,
+                };
+            }
+            2 => {
+                let mut var_condition = <crate::api::types::Condition>::sse_decode(deserializer);
+                return crate::api::types::Satisfaction::Complete {
+                    condition: var_condition,
+                };
+            }
+            3 => {
+                let mut var_msg = <String>::sse_decode(deserializer);
+                return crate::api::types::Satisfaction::None { msg: var_msg };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseDecode for crate::api::types::SatisfiableItem {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_key = <crate::api::types::PkOrF>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::EcdsaSignature { key: var_key };
+            }
+            1 => {
+                let mut var_key = <crate::api::types::PkOrF>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::SchnorrSignature { key: var_key };
+            }
+            2 => {
+                let mut var_hash = <String>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Sha256Preimage { hash: var_hash };
+            }
+            3 => {
+                let mut var_hash = <String>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Hash256Preimage { hash: var_hash };
+            }
+            4 => {
+                let mut var_hash = <String>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Ripemd160Preimage { hash: var_hash };
+            }
+            5 => {
+                let mut var_hash = <String>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Hash160Preimage { hash: var_hash };
+            }
+            6 => {
+                let mut var_value = <crate::api::types::LockTime>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::AbsoluteTimelock { value: var_value };
+            }
+            7 => {
+                let mut var_value = <u32>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::RelativeTimelock { value: var_value };
+            }
+            8 => {
+                let mut var_keys = <Vec<crate::api::types::PkOrF>>::sse_decode(deserializer);
+                let mut var_threshold = <u64>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Multisig {
+                    keys: var_keys,
+                    threshold: var_threshold,
+                };
+            }
+            9 => {
+                let mut var_items = <Vec<crate::api::types::BdkPolicy>>::sse_decode(deserializer);
+                let mut var_threshold = <u64>::sse_decode(deserializer);
+                return crate::api::types::SatisfiableItem::Thresh {
+                    items: var_items,
+                    threshold: var_threshold,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -4001,6 +4516,20 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::key::BdkMnemonic>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::BdkPolicy {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.ptr.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::BdkPolicy {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::BdkPolicy>
+    for crate::api::types::BdkPolicy
+{
+    fn into_into_dart(self) -> crate::api::types::BdkPolicy {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::psbt::BdkPsbt {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.ptr.into_into_dart().into_dart()].into_dart()
@@ -4127,6 +4656,24 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::ChangeSpendPolicy>
     for crate::api::types::ChangeSpendPolicy
 {
     fn into_into_dart(self) -> crate::api::types::ChangeSpendPolicy {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::Condition {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.csv.into_into_dart().into_dart(),
+            self.timelock.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::Condition {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::Condition>
+    for crate::api::types::Condition
+{
+    fn into_into_dart(self) -> crate::api::types::Condition {
         self
     }
 }
@@ -4487,6 +5034,31 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::Payload> for crate::ap
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::PkOrF {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::types::PkOrF::Pubkey { value } => {
+                [0.into_dart(), value.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::PkOrF::XOnlyPubkey { value } => {
+                [1.into_dart(), value.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::PkOrF::Fingerprint { value } => {
+                [2.into_dart(), value.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::PkOrF {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::PkOrF> for crate::api::types::PkOrF {
+    fn into_into_dart(self) -> crate::api::types::PkOrF {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::types::PsbtSigHashType {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.inner.into_into_dart().into_dart()].into_dart()
@@ -4569,6 +5141,120 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::blockchain::RpcSyncParams>
     for crate::api::blockchain::RpcSyncParams
 {
     fn into_into_dart(self) -> crate::api::blockchain::RpcSyncParams {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::Satisfaction {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::types::Satisfaction::Partial {
+                n,
+                m,
+                items,
+                sorted,
+                conditions,
+            } => [
+                0.into_dart(),
+                n.into_into_dart().into_dart(),
+                m.into_into_dart().into_dart(),
+                items.into_into_dart().into_dart(),
+                sorted.into_into_dart().into_dart(),
+                conditions.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::types::Satisfaction::PartialComplete {
+                n,
+                m,
+                items,
+                sorted,
+                conditions,
+            } => [
+                1.into_dart(),
+                n.into_into_dart().into_dart(),
+                m.into_into_dart().into_dart(),
+                items.into_into_dart().into_dart(),
+                sorted.into_into_dart().into_dart(),
+                conditions.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::types::Satisfaction::Complete { condition } => {
+                [2.into_dart(), condition.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::Satisfaction::None { msg } => {
+                [3.into_dart(), msg.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::types::Satisfaction
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::Satisfaction>
+    for crate::api::types::Satisfaction
+{
+    fn into_into_dart(self) -> crate::api::types::Satisfaction {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::SatisfiableItem {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::types::SatisfiableItem::EcdsaSignature { key } => {
+                [0.into_dart(), key.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::SchnorrSignature { key } => {
+                [1.into_dart(), key.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::Sha256Preimage { hash } => {
+                [2.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::Hash256Preimage { hash } => {
+                [3.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::Ripemd160Preimage { hash } => {
+                [4.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::Hash160Preimage { hash } => {
+                [5.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::AbsoluteTimelock { value } => {
+                [6.into_dart(), value.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::RelativeTimelock { value } => {
+                [7.into_dart(), value.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::types::SatisfiableItem::Multisig { keys, threshold } => [
+                8.into_dart(),
+                keys.into_into_dart().into_dart(),
+                threshold.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::types::SatisfiableItem::Thresh { items, threshold } => [
+                9.into_dart(),
+                items.into_into_dart().into_dart(),
+                threshold.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::types::SatisfiableItem
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::SatisfiableItem>
+    for crate::api::types::SatisfiableItem
+{
+    fn into_into_dart(self) -> crate::api::types::SatisfiableItem {
         self
     }
 }
@@ -4788,6 +5474,33 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::WordCount>
     }
 }
 
+impl SseEncode for std::collections::HashMap<String, Vec<usize>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(String, Vec<usize>)>>::sse_encode(self.into_iter().collect(), serializer);
+    }
+}
+
+impl SseEncode for std::collections::HashMap<Vec<u32>, Vec<crate::api::types::Condition>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(Vec<u32>, Vec<crate::api::types::Condition>)>>::sse_encode(
+            self.into_iter().collect(),
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for std::collections::HashMap<u32, Vec<crate::api::types::Condition>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(u32, Vec<crate::api::types::Condition>)>>::sse_encode(
+            self.into_iter().collect(),
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for RustOpaqueNom<bdk::bitcoin::Address> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4816,6 +5529,15 @@ impl SseEncode for RustOpaqueNom<bdk::blockchain::AnyBlockchain> {
 }
 
 impl SseEncode for RustOpaqueNom<bdk::descriptor::ExtendedDescriptor> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode for RustOpaqueNom<bdk::descriptor::Policy> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         let (ptr, size) = self.sse_encode_raw();
@@ -5258,6 +5980,13 @@ impl SseEncode for crate::api::key::BdkMnemonic {
     }
 }
 
+impl SseEncode for crate::api::types::BdkPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueNom<bdk::descriptor::Policy>>::sse_encode(self.ptr, serializer);
+    }
+}
+
 impl SseEncode for crate::api::psbt::BdkPsbt {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5340,6 +6069,14 @@ impl SseEncode for crate::api::types::ChangeSpendPolicy {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::types::Condition {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<u32>>::sse_encode(self.csv, serializer);
+        <Option<crate::api::types::LockTime>>::sse_encode(self.timelock, serializer);
     }
 }
 
@@ -5547,6 +6284,26 @@ impl SseEncode for crate::api::types::KeychainKind {
     }
 }
 
+impl SseEncode for Vec<crate::api::types::BdkPolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::types::BdkPolicy>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::types::Condition> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::types::Condition>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<Vec<u8>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5577,12 +6334,82 @@ impl SseEncode for Vec<crate::api::types::OutPoint> {
     }
 }
 
+impl SseEncode for Vec<crate::api::types::PkOrF> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::types::PkOrF>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<u32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <u32>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<u64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <u64>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <u8>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<usize> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <usize>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<(Vec<u32>, Vec<crate::api::types::Condition>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(Vec<u32>, Vec<crate::api::types::Condition>)>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<(String, Vec<usize>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(String, Vec<usize>)>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<(u32, Vec<crate::api::types::Condition>)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(u32, Vec<crate::api::types::Condition>)>::sse_encode(item, serializer);
         }
     }
 }
@@ -5674,6 +6501,16 @@ impl SseEncode for crate::api::types::Network {
     }
 }
 
+impl SseEncode for Option<std::collections::HashMap<String, Vec<usize>>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <std::collections::HashMap<String, Vec<usize>>>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5700,6 +6537,16 @@ impl SseEncode for Option<crate::api::descriptor::BdkDescriptor> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::descriptor::BdkDescriptor>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::types::BdkPolicy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::types::BdkPolicy>::sse_encode(value, serializer);
         }
     }
 }
@@ -5734,6 +6581,16 @@ impl SseEncode for Option<crate::api::types::BlockTime> {
     }
 }
 
+impl SseEncode for Option<bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <bool>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<f32> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5750,6 +6607,16 @@ impl SseEncode for Option<crate::api::types::FeeRate> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::types::FeeRate>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::types::LockTime> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::types::LockTime>::sse_encode(value, serializer);
         }
     }
 }
@@ -5868,6 +6735,29 @@ impl SseEncode for crate::api::types::Payload {
     }
 }
 
+impl SseEncode for crate::api::types::PkOrF {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::types::PkOrF::Pubkey { value } => {
+                <i32>::sse_encode(0, serializer);
+                <String>::sse_encode(value, serializer);
+            }
+            crate::api::types::PkOrF::XOnlyPubkey { value } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(value, serializer);
+            }
+            crate::api::types::PkOrF::Fingerprint { value } => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(value, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::api::types::PsbtSigHashType {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5914,12 +6804,36 @@ impl SseEncode
     }
 }
 
+impl SseEncode for (Vec<u32>, Vec<crate::api::types::Condition>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u32>>::sse_encode(self.0, serializer);
+        <Vec<crate::api::types::Condition>>::sse_encode(self.1, serializer);
+    }
+}
+
 impl SseEncode for (crate::api::types::OutPoint, crate::api::types::Input, usize) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::api::types::OutPoint>::sse_encode(self.0, serializer);
         <crate::api::types::Input>::sse_encode(self.1, serializer);
         <usize>::sse_encode(self.2, serializer);
+    }
+}
+
+impl SseEncode for (String, Vec<usize>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <Vec<usize>>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (u32, Vec<crate::api::types::Condition>) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.0, serializer);
+        <Vec<crate::api::types::Condition>>::sse_encode(self.1, serializer);
     }
 }
 
@@ -5941,6 +6855,108 @@ impl SseEncode for crate::api::blockchain::RpcSyncParams {
         <u64>::sse_encode(self.start_time, serializer);
         <bool>::sse_encode(self.force_start_time, serializer);
         <u64>::sse_encode(self.poll_rate_sec, serializer);
+    }
+}
+
+impl SseEncode for crate::api::types::Satisfaction {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::types::Satisfaction::Partial {
+                n,
+                m,
+                items,
+                sorted,
+                conditions,
+            } => {
+                <i32>::sse_encode(0, serializer);
+                <u64>::sse_encode(n, serializer);
+                <u64>::sse_encode(m, serializer);
+                <Vec<u64>>::sse_encode(items, serializer);
+                <Option<bool>>::sse_encode(sorted, serializer);
+                <std::collections::HashMap<u32, Vec<crate::api::types::Condition>>>::sse_encode(
+                    conditions, serializer,
+                );
+            }
+            crate::api::types::Satisfaction::PartialComplete {
+                n,
+                m,
+                items,
+                sorted,
+                conditions,
+            } => {
+                <i32>::sse_encode(1, serializer);
+                <u64>::sse_encode(n, serializer);
+                <u64>::sse_encode(m, serializer);
+                <Vec<u64>>::sse_encode(items, serializer);
+                <Option<bool>>::sse_encode(sorted, serializer);
+                <std::collections::HashMap<Vec<u32>, Vec<crate::api::types::Condition>>>::sse_encode(conditions, serializer);
+            }
+            crate::api::types::Satisfaction::Complete { condition } => {
+                <i32>::sse_encode(2, serializer);
+                <crate::api::types::Condition>::sse_encode(condition, serializer);
+            }
+            crate::api::types::Satisfaction::None { msg } => {
+                <i32>::sse_encode(3, serializer);
+                <String>::sse_encode(msg, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseEncode for crate::api::types::SatisfiableItem {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::types::SatisfiableItem::EcdsaSignature { key } => {
+                <i32>::sse_encode(0, serializer);
+                <crate::api::types::PkOrF>::sse_encode(key, serializer);
+            }
+            crate::api::types::SatisfiableItem::SchnorrSignature { key } => {
+                <i32>::sse_encode(1, serializer);
+                <crate::api::types::PkOrF>::sse_encode(key, serializer);
+            }
+            crate::api::types::SatisfiableItem::Sha256Preimage { hash } => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(hash, serializer);
+            }
+            crate::api::types::SatisfiableItem::Hash256Preimage { hash } => {
+                <i32>::sse_encode(3, serializer);
+                <String>::sse_encode(hash, serializer);
+            }
+            crate::api::types::SatisfiableItem::Ripemd160Preimage { hash } => {
+                <i32>::sse_encode(4, serializer);
+                <String>::sse_encode(hash, serializer);
+            }
+            crate::api::types::SatisfiableItem::Hash160Preimage { hash } => {
+                <i32>::sse_encode(5, serializer);
+                <String>::sse_encode(hash, serializer);
+            }
+            crate::api::types::SatisfiableItem::AbsoluteTimelock { value } => {
+                <i32>::sse_encode(6, serializer);
+                <crate::api::types::LockTime>::sse_encode(value, serializer);
+            }
+            crate::api::types::SatisfiableItem::RelativeTimelock { value } => {
+                <i32>::sse_encode(7, serializer);
+                <u32>::sse_encode(value, serializer);
+            }
+            crate::api::types::SatisfiableItem::Multisig { keys, threshold } => {
+                <i32>::sse_encode(8, serializer);
+                <Vec<crate::api::types::PkOrF>>::sse_encode(keys, serializer);
+                <u64>::sse_encode(threshold, serializer);
+            }
+            crate::api::types::SatisfiableItem::Thresh { items, threshold } => {
+                <i32>::sse_encode(9, serializer);
+                <Vec<crate::api::types::BdkPolicy>>::sse_encode(items, serializer);
+                <u64>::sse_encode(threshold, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 

--- a/test/bdk_flutter_test.mocks.dart
+++ b/test/bdk_flutter_test.mocks.dart
@@ -553,6 +553,15 @@ class MockWallet extends _i1.Mock implements _i3.Wallet {
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+
+  @override
+  _i3.Policy? policies(_i3.KeychainKind? keychain) => (super.noSuchMethod(
+        Invocation.method(
+          #policies,
+          [keychain],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i3.Policy?);
 }
 
 /// A class which mocks [Transaction].
@@ -1691,6 +1700,41 @@ class MockTxBuilder extends _i1.Mock implements _i3.TxBuilder {
           Invocation.method(
             #addUnSpendable,
             [unSpendable],
+          ),
+        ),
+      ) as _i3.TxBuilder);
+
+  @override
+  _i3.TxBuilder policyPath(
+    _i3.KeychainKind? keychain,
+    Map<String, _i7.Uint32List>? path,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #policyPath,
+          [
+            keychain,
+            path,
+          ],
+        ),
+        returnValue: _FakeTxBuilder_14(
+          this,
+          Invocation.method(
+            #policyPath,
+            [
+              keychain,
+              path,
+            ],
+          ),
+        ),
+        returnValueForMissingStub: _FakeTxBuilder_14(
+          this,
+          Invocation.method(
+            #policyPath,
+            [
+              keychain,
+              path,
+            ],
           ),
         ),
       ) as _i3.TxBuilder);


### PR DESCRIPTION
:warning: Depends on https://github.com/bitcoindevkit/bdk-ffi/pull/612

### Fixes

- Resolved issue with building a transaction using a multi-sig descriptor resulted in a Spending policy error.
- Added support for specifying a policy path in tx_builder using policy_path, enabling correct multi-sig spending policy specification during transaction creation.
### Enhancements
- Exposed policies() from the wallet to allow users to retrieve available spending policies for their wallet.