### PR TITLE
fix: add 16KB page alignment support for Android

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Ensure 16KB page alignment for Android targets.
+# Required by Google Play for Android 15+ (API 35+) compatibility.
+# NDK r28+ defaults to this, but explicit flags ensure alignment
+# regardless of NDK version or manual build configuration.
+
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.i686-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]

--- a/rust/cargokit.yaml
+++ b/rust/cargokit.yaml
@@ -1,6 +1,10 @@
 cargo:
   release:
     toolchain: stable
-precompiled_binaries:
-  url_prefix: https://github.com/LtbLightning/bdk-flutter/releases/download/precompiled_
-  public_key: 0e43d5e8452d00db7f3000c18fb1ba796babfcb5dc6306bb0629eff24f8be85b
+# Disabled: precompiled binaries are built with 4KB page alignment (0x1000).
+# Google Play now requires 16KB alignment (0x4000) for native libraries.
+# Building from source with NDK r28+ produces correct 16KB alignment.
+# Re-enable once precompiled binaries are rebuilt with 16KB page alignment.
+# precompiled_binaries:
+#   url_prefix: https://github.com/LtbLightning/bdk-flutter/releases/download/precompiled_
+#   public_key: 0e43d5e8452d00db7f3000c18fb1ba796babfcb5dc6306bb0629eff24f8be85b


### PR DESCRIPTION
## Summary

Google Play now requires 16KB page alignment (`0x4000`) for native libraries targeting Android 15+ (API 35+). The current precompiled binaries shipped via Cargokit are built with 4KB alignment (`0x1000`), causing Play Store rejection.

This PR disables precompiled binary downloads to force source builds, which produce correct 16KB alignment when using NDK r28+.

Closes #181

---

## Investigation & Root Cause

### How Cargokit Resolves Binaries

Cargokit computes a SHA-256 hash of the Rust source files (`src/*.rs`, `Cargo.toml`, `Cargo.lock`, `cargokit.yaml`) and uses it to look up precompiled binaries from the `url_prefix` in `cargokit.yaml`. If a matching binary is found, it's downloaded and used directly. Source compilation only happens as a fallback.

### The Problem

The precompiled binaries hosted at `https://github.com/LtbLightning/bdk-flutter/releases/download/precompiled_` were built with an older NDK that defaults to 4KB page alignment. We verified this by downloading the `aarch64-linux-android` release artifact and inspecting it:

```
$ llvm-readelf -l libbdk_flutter.so

Program Headers:
  Type   Offset   VirtAddr   PhysAddr   FileSiz  MemSiz   Flg  Align
  LOAD   0x000000 0x00000000 0x00000000 0x...    0x...    R    0x1000  ← 4KB
  LOAD   ...                                              R E  0x1000  ← 4KB
```

### Why .cargo/config.toml Alone Doesn't Fix It

During Flutter builds, Cargokit sets `CARGO_ENCODED_RUSTFLAGS` in `android_environment.dart`. This environment variable **overrides all other rustflags sources**, including `.cargo/config.toml`. So adding linker flags there only helps standalone `cargo build` invocations, not Flutter builds through Cargokit.

The actual 16KB alignment in Flutter builds comes from **NDK r28+ defaulting to it** in its linker.

---

## Changes

| File | Change |
|------|--------|
| `rust/cargokit.yaml` | Commented out `precompiled_binaries` to force source builds |
| `rust/.cargo/config.toml` | Added explicit 16KB linker flags for all Android targets (safety net for standalone cargo builds) |

## Verification

| Build Method | LOAD Alignment | Play Store |
|-------------|---------------|------------|
| Precompiled binary (current) | `0x1000` (4KB) | Rejected |
| Source build, NDK r28+ | `0x4000` (16KB) | Accepted |

Tested end-to-end: built a Flutter app depending on bdk-flutter with this change, extracted `libbdk_flutter.so` from the APK, and confirmed `0x4000` alignment via `llvm-readelf -l`.

## Tradeoffs

- **Build time increases** — source compilation instead of downloading precompiled binaries
- **Recommended permanent fix** — rebuild and republish precompiled binaries using NDK r28+, then re-enable the `precompiled_binaries` section. The config is commented out (not removed) to make this easy.